### PR TITLE
Fix client crash: lazy CategoryIcon recipe-viewer wrapper (JEI runtime accessed during RegisterEvent)

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/recipeviewer/CategoryIcon.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/recipeviewer/CategoryIcon.java
@@ -14,27 +14,36 @@ import mezz.jei.api.gui.drawable.IDrawable;
 // Generic recipe viewer category icon
 public class CategoryIcon {
 
+    // Resolved lazily: constructing icons happens during RegisterEvent dispatch
+    // (GTRecipeCategories.init), when the JEI runtime does not exist yet —
+    // calling GTJEIPlugin.getRuntime() there crashes the client (unbound
+    // gtceu:data_item follow-up). Defer wrapper creation to first get().
     private Object wrappedValue;
+    private ResourceLocation texture;
+    private ItemStack stack;
+    private boolean resolved = false;
 
     public CategoryIcon(ResourceLocation texture) {
-        if (!GTCEu.isClientSide()) return;
-        if (GTCEu.Mods.isEMILoaded()) {
-            wrappedValue = EmiCallWrapper.getRenderable(texture);
-        } else if (GTCEu.Mods.isJEILoaded()) {
-            wrappedValue = JeiCallWrapper.getRenderable(texture);
-        }
+        this.texture = texture;
     }
 
     public CategoryIcon(ItemStack stack) {
-        if (!GTCEu.isClientSide()) return;
-        if (GTCEu.Mods.isEMILoaded()) {
-            wrappedValue = EmiCallWrapper.getRenderable(stack);
-        } else if (GTCEu.Mods.isJEILoaded()) {
-            wrappedValue = JeiCallWrapper.getRenderable(stack);
-        }
+        this.stack = stack;
     }
 
     public Object get() {
+        if (!resolved) {
+            resolved = true;
+            if (GTCEu.isClientSide()) {
+                if (GTCEu.Mods.isEMILoaded()) {
+                    wrappedValue = texture != null ? EmiCallWrapper.getRenderable(texture) :
+                            EmiCallWrapper.getRenderable(stack);
+                } else if (GTCEu.Mods.isJEILoaded()) {
+                    wrappedValue = texture != null ? JeiCallWrapper.getRenderable(texture) :
+                            JeiCallWrapper.getRenderable(stack);
+                }
+            }
+        }
         return wrappedValue;
     }
 


### PR DESCRIPTION
## What

Fixes a client crash on world-independent startup when JEI is installed (and EMI is not): `CategoryIcon` constructors run during the `RegisterEvent` dispatch (`GTRecipeCategories.init()` inside `CommonProxy.onRegister`) and immediately call `GTJEIPlugin.getRuntime()`, which does not exist yet.

The resulting `ExceptionInInitializerError` aborts `onRegister` midway, so `GTDataComponents.DATA_COMPONENTS` never registers, and item registration then dies with:

```
java.lang.NullPointerException: Trying to access unbound value: ResourceKey[minecraft:data_component_type / gtceu:data_item]
	(while registering gtceu:data_stick)
```

## Implementation Details

`CategoryIcon` now stores the raw `ResourceLocation`/`ItemStack` and resolves the EMI/JEI wrapper lazily on the first `get()` call — by then the recipe-viewer runtime exists. Behavior for EMI (which was safe eagerly) is unchanged apart from the deferral.

### AI Usage

- [x] Yes AI driven tools were used for this pull request.

#### Agent Used
Claude Code (Claude Fable 5)

#### Agent Usage Description
The agent diagnosed the crash from our modpack's crash report, traced the eager `getRuntime()` call, and wrote the lazy-resolution patch and this PR text. The diff was reviewed by the submitter before opening.

## Outcome

Client starts normally with JEI-only recipe viewer setups on 1.21 HEAD.

## How Was This Tested

Reproduced the crash in our 1.21.1 pack (JEI 19.38, no EMI) on a build of 1.21 HEAD (`1023cb75`); with this patch applied the client boots and GT items/data components register normally. Dedicated server was unaffected before and after (the JEI wrapper path is never taken there).

## Potential Compatibility Issues

None expected — `get()` callers receive the same wrapper objects, just created on first use instead of at registration time.
