### PR TITLE
Fix some Programmed Circuit c0 behaviors

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/item/behavior/IntCircuitBehaviour.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/behavior/IntCircuitBehaviour.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.common.item.behavior;
 
+import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.item.component.IAddInformation;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.machine.trait.notifiable.NotifiableItemStackHandler;
@@ -37,8 +38,10 @@ public class IntCircuitBehaviour implements IAddInformation, IItemUIHolder {
     }
 
     public static void setCircuitConfiguration(ItemStack itemStack, int configuration) {
-        if (configuration < 0 || configuration > CIRCUIT_MAX)
-            throw new IllegalArgumentException("Given configuration number is out of range!");
+        if (configuration < 0 || configuration > CIRCUIT_MAX) {
+            GTCEu.LOGGER.error("Given circuit configuration %d is out of range!".formatted(configuration));
+            configuration = 0;
+        }
         var tagCompound = itemStack.getOrCreateTag();
         tagCompound.putInt("Configuration", configuration);
     }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/trait/ProgrammableCircuitSlotTrait.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/trait/ProgrammableCircuitSlotTrait.java
@@ -16,6 +16,7 @@ import com.gregtechceu.gtceu.common.item.behavior.IntCircuitBehaviour;
 import com.gregtechceu.gtceu.common.mui.GTMuiWidgets;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 
 import brachy.modularui.screen.ModularPanel;
@@ -54,7 +55,10 @@ public class ProgrammableCircuitSlotTrait extends NotifiableRecipeHandlerTrait<I
     }
 
     public void setCurrentCircuit(int circuit) {
-        storage.setStackInSlot(0, IntCircuitBehaviour.stack(circuit));
+        if (circuit > 0)
+            storage.setStackInSlot(0, IntCircuitBehaviour.stack(circuit));
+        else
+            storage.setStackInSlot(0, ItemStack.EMPTY);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/common/mui/GTMuiWidgets.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/mui/GTMuiWidgets.java
@@ -244,7 +244,7 @@ public class GTMuiWidgets {
                         .value(new BoolValue.Dynamic(() -> (i + 1) == circuitSyncValue.getIntValue(),
                                 (v) -> {
                                     if (v) circuitSyncValue.setValue(i + 1);
-                                    else circuitSyncValue.setValue(-1);
+                                    else circuitSyncValue.setValue(0);
                                 })));
 
         return new Dialog<>("circuit_panel")
@@ -317,7 +317,7 @@ public class GTMuiWidgets {
         if (delta > 0) {
             if (current == IntCircuitBehaviour.CIRCUIT_MAX) {
                 // if at max, loop around to no circuit
-                return 0;
+                return -1;
             } else if (stack.isEmpty()) {
                 // if at no circuit, skip 0 and return 1
                 return 1;


### PR DESCRIPTION
## What
Fixes four strange behaviors involving Programmed Circuits on Configuration 0 (c0)
- When setting a Programmed Circuit in-hand, resetting it to c0 _deletes the item without closing the UI_
- When mousewheel scrolling a machine's circuit slot up from 32 or down from 1, going one way results in c0 but going the other way results in No Circuit
- When pasting a circuit into a machine, the machine is set to c0, which is useless
- Setting a programmed circuit to config -1 triggered a server crash

### AI Usage 
- [ X ] No AI driven tools were used for this pull request.

## Outcome
- Circuits in hand can now be reset to c0
- Scrolling circuit config in a machine now sets the machine to No Circuit
- Pasting a c0 circuit into a machine sets the machine to No Circuit
- Setting a programmed circuit to an invalid config now sets the circuit to c0 and prints an error log rather than triggering a crash

## How Was This Tested
creative test world

### Additional Information
There's another programmed circuit behavior I want to fix with the Jade Provider but that'll be a separate PR.