### PR TITLE
Fix Adv Fluid Void copy/pasting wrong and having its void limit clamped

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/cover/voiding/AdvancedFluidVoidingCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/voiding/AdvancedFluidVoidingCover.java
@@ -38,6 +38,8 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @ParametersAreNonnullByDefault
 public class AdvancedFluidVoidingCover extends FluidVoidingCover {
 
+    private static final int MAX_STACK_SIZE = 2_048_000_000; // Capacity of quantum tank IX
+
     @SaveField
     @SyncToClient
     @Getter
@@ -141,17 +143,8 @@ public class AdvancedFluidVoidingCover extends FluidVoidingCover {
 
         column.child(
                 GTMuiWidgets
-                        .createIntInputWithBucketMode(voidingLimit, bucketModeSync, () -> getVoidingMode().maxStackSize)
+                        .createIntInputWithBucketMode(voidingLimit, bucketModeSync, () -> MAX_STACK_SIZE)
                         .setEnabledIf($ -> shouldShowStackSize()));
-    }
-
-    private int getCurrentBucketModeTransferSize() {
-        return this.globalTransferSizeMillibuckets / this.transferBucketMode.multiplier;
-    }
-
-    private void setCurrentBucketModeTransferSize(int transferSize) {
-        this.globalTransferSizeMillibuckets = Math.max(transferSize * this.transferBucketMode.multiplier, 0);
-        syncDataHolder.markClientSyncFieldDirty("globalTransferSizeMillibuckets");
     }
 
     @Override
@@ -182,7 +175,7 @@ public class AdvancedFluidVoidingCover extends FluidVoidingCover {
     public void pasteConfig(ServerPlayer player, CompoundTag tag) {
         setVoidingMode(VoidingMode.values()[tag.getInt("voidingMode")]);
         setTransferBucketMode(BucketMode.values()[tag.getInt("voidBucketMode")]);
-        setCurrentBucketModeTransferSize(tag.getInt("voidSize"));
+        setGlobalTransferSizeMillibuckets(tag.getInt("voidSize"));
         super.pasteConfig(player, tag);
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/voiding/AdvancedFluidVoidingCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/voiding/AdvancedFluidVoidingCover.java
@@ -37,8 +37,6 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @ParametersAreNonnullByDefault
 public class AdvancedFluidVoidingCover extends FluidVoidingCover {
 
-    private static final int MAX_STACK_SIZE = 2_048_000_000; // Capacity of quantum tank IX
-
     @SaveField
     @SyncToClient
     @Getter
@@ -138,7 +136,7 @@ public class AdvancedFluidVoidingCover extends FluidVoidingCover {
 
         column.child(
                 GTMuiWidgets
-                        .createIntInputWithBucketMode(voidingLimit, bucketModeSync, () -> MAX_STACK_SIZE)
+                        .createIntInputWithBucketMode(voidingLimit, bucketModeSync, () -> Integer.MAX_VALUE)
                         .setEnabledIf($ -> shouldShowStackSize()));
     }
 


### PR DESCRIPTION
## What
Advanced Fluid Voiding Covers copy/paste would paste the new cover with an incorrect fluid setting, and their void config limit was unusually small.

## Implementation Details
(Fluid Voiding Covers also will not work correctly without #5323 but that's unrelated to this.)

### AI Usage 
- [ X ] No AI driven tools were used for this pull request.
  
## Outcome
pastes correctly now and isn't clamped to a very low threshold