### PR TITLE
Fix typo in `DaytimeCondition`

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/recipe/condition/DaytimeCondition.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/recipe/condition/DaytimeCondition.java
@@ -20,7 +20,7 @@ public class DaytimeCondition extends RecipeCondition<DaytimeCondition> {
 
     // spotless:off
     public static final Codec<DaytimeCondition> CODEC = RecipeCondition.simpleCodec(DaytimeCondition::new);
-    // spotless:off
+    // spotless:on
 
     public DaytimeCondition(boolean isReverse) {
         super(isReverse);


### PR DESCRIPTION
I just replaced `spotless:off` with `spotless:on` in a place where there was almost certainly a typo in a spotless comment. I also ran spotless just to check, but nothing seems to have changed, soooo…