### PR TITLE
Remove a few unnecessary ClientSyncFields

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/notifiable/NotifiableEnergyContainer.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/notifiable/NotifiableEnergyContainer.java
@@ -13,7 +13,6 @@ import com.gregtechceu.gtceu.api.misc.EnergyContainerList;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.ingredient.EnergyStack;
 import com.gregtechceu.gtceu.api.sync_system.annotations.SaveField;
-import com.gregtechceu.gtceu.api.sync_system.annotations.SyncToClient;
 import com.gregtechceu.gtceu.common.machine.trait.EnvironmentalExplosionTrait;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.utils.GTUtil;
@@ -41,7 +40,6 @@ public class NotifiableEnergyContainer extends NotifiableRecipeHandlerTrait<Ener
     protected IO handlerIO;
     @Getter
     @SaveField
-    @SyncToClient
     protected long energyStored;
     @Getter
     private long energyCapacity, inputVoltage, inputAmperage, outputVoltage, outputAmperage;
@@ -141,7 +139,6 @@ public class NotifiableEnergyContainer extends NotifiableRecipeHandlerTrait<Ener
             energyOutputPerSec += this.energyStored - energyStored;
         }
         this.energyStored = energyStored;
-        syncDataHolder.markClientSyncFieldDirty("energyStored");
         checkOutputSubscription();
         notifyListeners();
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/recipe/RecipeLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/recipe/RecipeLogic.java
@@ -120,7 +120,6 @@ public class RecipeLogic extends MachineTrait implements IWorkable {
 
     @SaveField
     @Getter
-    @SyncToClient
     protected int progress;
     @Getter
     @SyncToClient
@@ -237,7 +236,6 @@ public class RecipeLogic extends MachineTrait implements IWorkable {
 
     public void setProgress(int progress) {
         this.progress = progress;
-        syncDataHolder.markClientSyncFieldDirty("progress");
     }
 
     public void setProgressDelta(int delta) {
@@ -336,7 +334,6 @@ public class RecipeLogic extends MachineTrait implements IWorkable {
                 }
                 progress++;
                 totalContinuousRunningTime++;
-                syncDataHolder.markClientSyncFieldDirty("progress");
             } else {
                 setWaiting(handleTick.reason());
 
@@ -378,7 +375,6 @@ public class RecipeLogic extends MachineTrait implements IWorkable {
     protected void regressRecipe() {
         if (progress > 0 && regressWhenWaiting) {
             this.progress = 1;
-            syncDataHolder.markClientSyncFieldDirty("progress");
         }
     }
 
@@ -656,7 +652,6 @@ public class RecipeLogic extends MachineTrait implements IWorkable {
             setStatus(Status.IDLE);
             progress = 0;
             duration = 0;
-            syncDataHolder.markClientSyncFieldDirty("progress");
             syncDataHolder.markClientSyncFieldDirty("duration");
         }
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/recipe/RecipeLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/recipe/RecipeLogic.java
@@ -115,14 +115,12 @@ public class RecipeLogic extends MachineTrait implements IWorkable {
 
     @Getter
     @SaveField
-    @SyncToClient
     protected int consecutiveRecipes = 0; // Consecutive recipes that have been run
 
     @SaveField
     @Getter
     protected int progress;
     @Getter
-    @SyncToClient
     @SaveField
     protected int duration;
     @Getter(onMethod_ = @VisibleForTesting)
@@ -652,7 +650,6 @@ public class RecipeLogic extends MachineTrait implements IWorkable {
             setStatus(Status.IDLE);
             progress = 0;
             duration = 0;
-            syncDataHolder.markClientSyncFieldDirty("duration");
         }
     }
 


### PR DESCRIPTION
## What
Every tick, every active machine serializes and syncs to client
- the contents of its Energy Container
- the progress ticks on its recipe

Furthermore on recipe start or finish, every active machine serializes and syncs to client
- The currently selected recipe
- The recipe's duration
- The number of consecutive recipes completed

Certain machines use the Currently Selected Recipe for custom rendering. While this should be redone more efficiently that is outside the scope of this PR. What is the scope of this PR is removing the client sync of the other four; as the client really doesn't need to know about them outside of a GUI or Jade readout, both of which have their own sync providers.

## Implementation Details
This one's simple: just removing those four SyncToClient annotations and associated markAsDirty calls

### AI Usage 
- [ X ] No AI driven tools were used for this pull request.

## Outcome
- No sync packets sent per-machine per-tick **at all**. This hugely reduces ongoing network bandwidth
- Slightly reduced size of on-recipe-start/finish sync packets

## How Was This Tested
Creative world, debug monitoring calls to SyncDataHolder.readClientPacket()

## Potential Compatibility Issues
A PR focused on refining how the current recipe is serialized would be addon-breaking which is why that one is out of scope.

However, this one should not be breaking, unless an addon _does_ use a custom renderer that relies on either currently selected recipe or current recipe progress over duration. I do not know of any addons that do a custom render like this.