### PR TITLE
Fix KubeJS not working with the recipe type registry change

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/sync_system/data_transformers/ValueTransformers.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/sync_system/data_transformers/ValueTransformers.java
@@ -4,7 +4,6 @@ import com.gregtechceu.gtceu.api.cover.CoverBehavior;
 import com.gregtechceu.gtceu.api.data.chemical.material.Material;
 import com.gregtechceu.gtceu.api.recipe.ConsumedInputsData;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
-import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;
 import com.gregtechceu.gtceu.api.sync_system.SyncDataHolder;
 import com.gregtechceu.gtceu.api.sync_system.TypeDeclaration;
@@ -177,7 +176,6 @@ public final class ValueTransformers {
         registerCodecTransformer(MonitorGroup.class, MonitorGroup.CODEC, MonitorGroup.STREAM_CODEC);
         registerCodecTransformer(ConsumedInputsData.class, ConsumedInputsData.CODEC, ByteBufCodecs.fromCodecWithRegistries(ConsumedInputsData.CODEC));
 
-        registerTransformer(GTRecipeType.class, new RegistryReferenceTransformer<>(GTRegistries.Keys.RECIPE_TYPE, GTRecipeType::getRegistryName));
         registerTransformer(Material.class, new RegistryReferenceTransformer<>(GTRegistries.Keys.MATERIAL, Material::getResourceLocation));
 
         // spotless:on

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/GTCEuStartupEvents.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/GTCEuStartupEvents.java
@@ -1,16 +1,26 @@
 package com.gregtechceu.gtceu.integration.kjs;
 
+import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.integration.kjs.events.*;
 
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
 
 import dev.latvian.mods.kubejs.event.EventGroup;
 import dev.latvian.mods.kubejs.event.EventHandler;
 import dev.latvian.mods.kubejs.event.EventTargetType;
 import dev.latvian.mods.kubejs.event.TargetedEventHandler;
+import dev.latvian.mods.kubejs.util.Cast;
+import dev.latvian.mods.rhino.type.TypeInfo;
 
 public interface GTCEuStartupEvents {
+
+    EventTargetType<ResourceKey<Registry<?>>> REGISTRY_ASSUME_GT = Cast.to(EventTargetType.create(ResourceKey.class)
+            .transformer(GTCEuStartupEvents::toRegistryKeyAssumeGTNamespace)
+            .identity()
+            .describeType(TypeInfo.of(ResourceKey.class)
+                    .withParams(TypeInfo.of(Registry.class))));
 
     EventGroup GROUP = EventGroup.of("GTCEuStartupEvents");
 
@@ -18,12 +28,24 @@ public interface GTCEuStartupEvents {
     EventHandler WORLD_GEN_LAYERS = GROUP.startup("worldGenLayers", () -> WorldGenLayerEventJS.class);
 
     TargetedEventHandler<ResourceKey<Registry<?>>> REGISTRY = GROUP.startup("registry", () -> GTRegistryKubeEvent.class)
-            .requiredTarget(EventTargetType.REGISTRY);
-    EventHandler MATERIAL_MODIFICATION = GROUP.startup("materialModification",
-            () -> MaterialModificationEventJS.class);
+            .requiredTarget(REGISTRY_ASSUME_GT);
+    EventHandler MATERIAL_MODIFICATION = GROUP.startup("materialModification", () -> MaterialModificationEventJS.class);
     EventHandler CRAFTING_COMPONENTS = GROUP.startup("craftingComponents", () -> CraftingComponentsEventJS.class);
 
     EventHandler REGISTER_WOODS = GROUP.startup("registerWoods", () -> RegisterWoodsEventJS.class);
     EventHandler MACHINE_MODIFICATION = GROUP.startup("machineModification", () -> ModifyMachineEventJS.class);
     EventHandler REGISTER_SPOILABLES = GROUP.startup("registerSpoilables", () -> RegisterSpoilablesEventJS.class);
+
+    @SuppressWarnings("rawtypes")
+    private static ResourceKey<? extends Registry<?>> toRegistryKeyAssumeGTNamespace(Object object) {
+        return switch (object) {
+            case null -> null;
+            case ResourceKey rl -> rl;
+            case ResourceLocation rl -> ResourceKey.createRegistryKey(rl);
+            default -> {
+                String s = object.toString();
+                yield s.isBlank() ? null : ResourceKey.createRegistryKey(GTCEu.id(s));
+            }
+        };
+    }
 }

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
@@ -135,6 +135,9 @@ public class GregTechKubeJSPlugin implements KubeJSPlugin {
             reg.add(GTCEu.id("ore"), OreTagPrefixBuilder.class, OreTagPrefixBuilder::new);
         });
 
+        registry.of(Registries.RECIPE_TYPE, reg -> {
+            reg.add(GTCEu.id("machine"), GTRecipeTypeBuilder.class, GTRecipeTypeBuilder::new);
+        });
         registry.addDefault(GTRegistries.Keys.RECIPE_TYPE, GTRecipeTypeBuilder.class, GTRecipeTypeBuilder::new);
         registry.addDefault(GTRegistries.Keys.RECIPE_CATEGORY, GTRecipeCategoryBuilder.class,
                 GTRecipeCategoryBuilder::new);

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
@@ -116,11 +116,15 @@ import dev.latvian.mods.kubejs.recipe.schema.RecipeFactoryRegistry;
 import dev.latvian.mods.kubejs.recipe.schema.RecipeSchemaRegistry;
 import dev.latvian.mods.kubejs.registry.BuilderTypeRegistry;
 import dev.latvian.mods.kubejs.registry.RegistryObjectStorage;
+import dev.latvian.mods.kubejs.registry.RegistryType;
 import dev.latvian.mods.kubejs.registry.ServerRegistryRegistry;
 import dev.latvian.mods.kubejs.script.BindingRegistry;
 import dev.latvian.mods.kubejs.script.TypeWrapperRegistry;
+import dev.latvian.mods.kubejs.util.ID;
 import dev.latvian.mods.kubejs.util.RegistryAccessContainer;
+import dev.latvian.mods.rhino.Context;
 import dev.latvian.mods.rhino.Wrapper;
+import dev.latvian.mods.rhino.type.TypeInfo;
 
 public class GregTechKubeJSPlugin implements KubeJSPlugin {
 
@@ -342,7 +346,22 @@ public class GregTechKubeJSPlugin implements KubeJSPlugin {
     public void registerTypeWrappers(TypeWrapperRegistry registry) {
         registry.register(GTResourceLocation.class, GTResourceLocation::wrap);
 
-        registryObjectTypeWrapper(registry, GTRecipeType.class, GTRegistries.Keys.RECIPE_TYPE);
+        registry.register(GTRecipeType.class, (Context cx, Object from, TypeInfo target) -> {
+            if (ID.isKey(from)) {
+                // if it's an ID, make it default to the GT namespace
+                GTResourceLocation wrapper = GTResourceLocation.wrap(from);
+                if (wrapper != null) from = wrapper.wrapped();
+            }
+
+            // first convert
+            Object o = cx.jsToJava(from, RegistryType.ofKey(Registries.RECIPE_TYPE).type());
+            if (o instanceof GTRecipeType gtType) {
+                return gtType;
+            } else {
+                cx.reportConversionError(from, target);
+                return null;
+            }
+        });
         registryObjectTypeWrapper(registry, GTRecipeCategory.class, GTRegistries.Keys.RECIPE_CATEGORY);
         registryObjectTypeWrapper(registry, ChanceLogic.class, GTRegistries.Keys.CHANCE_LOGIC);
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/GTRecipeTypeBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/GTRecipeTypeBuilder.java
@@ -51,6 +51,8 @@ public class GTRecipeTypeBuilder extends BuilderBase<GTRecipeType> {
         this.maxTooltips = 4;
         this.smallRecipeMap = null;
         this.iconSupplier = null;
+
+        this.dummyBuilder = true;
     }
 
     public GTRecipeTypeBuilder category(String category) {

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/helpers/KubeGTRegistryEventHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/helpers/KubeGTRegistryEventHandler.java
@@ -31,7 +31,7 @@ public class KubeGTRegistryEventHandler {
     @SubscribeEvent(priority = EventPriority.LOW)
     public static void registerAll(RegisterEvent event) {
         // only post the GT registry event for GT registries
-        if (!GTRegistries.getRegistries().contains(event.getRegistry())) {
+        if (!GTRegistries.getRegistryOrder().contains(event.getRegistryKey().location())) {
             return;
         }
 


### PR DESCRIPTION
## What
Added the GT machine recipe type builder to KJS's **vanilla** recipe type builder registry & fixed it

removed the unused `GTRecipeType` value transformer.

## Implementation Details
### AI Usage 
- [x] No AI driven tools were used for this pull request.
- [ ] Yes AI driven tools were used for this pull request.
  
## Outcome
You can use the vanilla recipe type registry for registering GT machine recipe types. Registering custom recipe types or using GT recipe types with custom machines also works again.

## How Was This Tested
Used the following script (in additional information section). All variants work.

## Additional Information
The script:
```js
GTCEuStartupEvents.registry('recipe_type', event => {
    event.create('kubejs:test_1')
        .category('test')
        .setEUIO('in')
        .setMaxIOSize(0, 1, 2, 3)
        .setItemSlotOverlay(IO.IN, 0, GTGuiTextures.SOLIDIFIER_OVERLAY)
        .setProgressBar(GTGuiTextures.PROGRESS_ARROW)
        .setSound(GTSoundEntries.COOLING)
})

StartupEvents.registry('gtceu:recipe_type', event => {
    event.create('test_2')
        .category('test')
        .setEUIO('in')
        .setMaxIOSize(1, 2, 3, 0)
        .setProgressBar(GTGuiTextures.PROGRESS_ASSEMBLER)
        .setSound(GTSoundEntries.FURNACE)
})

GTCEuStartupEvents.registry('minecraft:recipe_type', event => {
    event.create('kubejs:test_3', 'gtceu:machine')
        .category('test')
        .setEUIO('in')
        .setMaxIOSize(2, 3, 0, 1)
        .setProgressBar(GTGuiTextures.PROGRESS_CRYSTALLIZATION)
        .setSound(GTSoundEntries.JET_ENGINE)
})

StartupEvents.registry('recipe_type', event => {
    event.create('test_4', 'gtceu:machine')
        .category('test')
        .setEUIO('in')
        .setMaxIOSize(3, 0, 1, 2)
        .setProgressBar(GTGuiTextures.PROGRESS_MAGNET)
        .setSound(GTSoundEntries.MOTOR)
})
```