### PR TITLE
Make spoilage less intrusive

### DIFF
--- a/src/generated/resources/assets/gtceu/lang/en_ud.json
+++ b/src/generated/resources/assets/gtceu/lang/en_ud.json
@@ -3986,7 +3986,7 @@
   "gtceu.tooltip.proxy_bind": "%s %s %s ʇɐ ɹǝɟɟnᗺ uɹǝʇʇɐԀ ɐ oʇ buıpuıᗺɟ§",
   "gtceu.tooltip.spoil_time_remaining": "%s :sןıods ןıʇun ǝɯı⟘",
   "gtceu.tooltip.spoil_time_total": "%s :ǝɯıʇ ןıods ןɐʇo⟘",
-  "gtceu.tooltip.spoiled_time_ago": "˙obɐ %s pǝןıodS\n¡ʎɹoʇuǝʌuı pǝʇɹoddns ɐ buıɹǝʇuǝ uodn ɯɹoɟsuɐɹʇ ןןıʍ ɯǝʇı sıɥ⟘",
+  "gtceu.tooltip.spoiled_time_ago": "obɐ %s pǝןıodS\nɹ§¡ʎɹoʇuǝʌuı pǝʇɹoddns ɐ buıɹǝʇuǝ uodn ɯɹoɟsuɐɹʇ ןןıʍ ɯǝʇı sıɥ⟘q§",
   "gtceu.tooltip.spoils_into": "%s :oʇuı sןıodS",
   "gtceu.tooltip.status.trinary.false": "ǝsןɐℲ",
   "gtceu.tooltip.status.trinary.true": "ǝnɹ⟘",

--- a/src/generated/resources/assets/gtceu/lang/en_ud.json
+++ b/src/generated/resources/assets/gtceu/lang/en_ud.json
@@ -3986,6 +3986,7 @@
   "gtceu.tooltip.proxy_bind": "%s %s %s ʇɐ ɹǝɟɟnᗺ uɹǝʇʇɐԀ ɐ oʇ buıpuıᗺɟ§",
   "gtceu.tooltip.spoil_time_remaining": "%s :sןıods ןıʇun ǝɯı⟘",
   "gtceu.tooltip.spoil_time_total": "%s :ǝɯıʇ ןıods ןɐʇo⟘",
+  "gtceu.tooltip.spoiled_time_ago": "˙obɐ %s pǝןıodS\n¡ʎɹoʇuǝʌuı pǝʇɹoddns ɐ buıɹǝʇuǝ uodn ɯɹoɟsuɐɹʇ ןןıʍ ɯǝʇı sıɥ⟘",
   "gtceu.tooltip.spoils_into": "%s :oʇuı sןıodS",
   "gtceu.tooltip.status.trinary.false": "ǝsןɐℲ",
   "gtceu.tooltip.status.trinary.true": "ǝnɹ⟘",

--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -3986,6 +3986,7 @@
   "gtceu.tooltip.proxy_bind": "§fBinding to a Pattern Buffer at %s %s %s",
   "gtceu.tooltip.spoil_time_remaining": "Time until spoils: %s",
   "gtceu.tooltip.spoil_time_total": "Total spoil time: %s",
+  "gtceu.tooltip.spoiled_time_ago": "This item will transform upon entering a supported inventory!\nSpoiled %s ago.",
   "gtceu.tooltip.spoils_into": "Spoils into: %s",
   "gtceu.tooltip.status.trinary.false": "False",
   "gtceu.tooltip.status.trinary.true": "True",

--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -3986,7 +3986,7 @@
   "gtceu.tooltip.proxy_bind": "§fBinding to a Pattern Buffer at %s %s %s",
   "gtceu.tooltip.spoil_time_remaining": "Time until spoils: %s",
   "gtceu.tooltip.spoil_time_total": "Total spoil time: %s",
-  "gtceu.tooltip.spoiled_time_ago": "This item will transform upon entering a supported inventory!\nSpoiled %s ago.",
+  "gtceu.tooltip.spoiled_time_ago": "§bThis item will transform upon entering a supported inventory!§r\nSpoiled %s ago",
   "gtceu.tooltip.spoils_into": "Spoils into: %s",
   "gtceu.tooltip.status.trinary.false": "False",
   "gtceu.tooltip.status.trinary.true": "True",

--- a/src/main/java/com/gregtechceu/gtceu/api/item/ISpoilableItemStackExtension.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/ISpoilableItemStackExtension.java
@@ -1,8 +1,0 @@
-package com.gregtechceu.gtceu.api.item;
-
-import net.minecraft.world.item.ItemStack;
-
-public interface ISpoilableItemStackExtension {
-
-    void gtceu$setStack(ItemStack newStack);
-}

--- a/src/main/java/com/gregtechceu/gtceu/api/item/component/ISpoilableItem.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/component/ISpoilableItem.java
@@ -71,6 +71,11 @@ public interface ISpoilableItem {
     long getSpoilTicks();
 
     /**
+     * @return whether the item should have spoiled and will be replaced when entering a supported inventory
+     */
+    boolean shouldHaveSpoiled();
+
+    /**
      * @return the amount of ticks left until the provided {@link ItemStack} spoils.
      *         The ticks still reduce even when the item is unloaded, and only pause if the
      *         overworld time pauses, as all tick calculations are done with overworld tick time

--- a/src/main/java/com/gregtechceu/gtceu/api/item/component/SpoilContext.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/component/SpoilContext.java
@@ -4,6 +4,7 @@ import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.transfer.item.CustomItemStackHandler;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.registries.Registries;
@@ -43,15 +44,26 @@ public record SpoilContext(@Nullable Level level,
                            @Nullable CompoundTag itemHandlerData,
                            int slot) {
 
+    public static final SpoilContext EMPTY = new SpoilContext();
+
     /**
      * @return the {@link Level} used to determine time to calculate spoilage progress (using
      *         {@link Level#getGameTime()}).
      *         This is usually the Overworld. If it is {@code null}, all spoilage updates are ignored.
      */
     public static @Nullable Level getDefaultLevel() {
+        if (GTCEu.isClientThread())
+            return ClientLevelGetterWrapper.getLevel();
         MinecraftServer server = ServerLifecycleHooks.getCurrentServer();
         if (server == null) return null;
         return server.overworld();
+    }
+
+    private static final class ClientLevelGetterWrapper {
+
+        public static @Nullable Level getLevel() {
+            return Minecraft.getInstance().level;
+        }
     }
 
     public SpoilContext() {
@@ -111,11 +123,20 @@ public record SpoilContext(@Nullable Level level,
     }
 
     public static SpoilContext deserializeNBT(CompoundTag tag) {
-        SpoilContext ctx = new SpoilContext();
+        SpoilContext ctx = SpoilContext.EMPTY;
         if (tag.contains("level")) {
-            ctx = ctx.withLevel(ServerLifecycleHooks.getCurrentServer().getLevel(ResourceKey.create(
-                    Registries.DIMENSION,
-                    new ResourceLocation(tag.getString("level")))));
+            if (GTCEu.isClientThread()) {
+                Level level = ClientLevelGetterWrapper.getLevel();
+                if (level != null) {
+                    String dimension = level.dimensionTypeId().location().toString();
+                    if (dimension.equals(tag.getString("level")))
+                        ctx = ctx.withLevel(level);
+                }
+            } else {
+                ctx = ctx.withLevel(ServerLifecycleHooks.getCurrentServer().getLevel(ResourceKey.create(
+                        Registries.DIMENSION,
+                        ResourceLocation.parse(tag.getString("level")))));
+            }
         }
         if (tag.contains("pos")) {
             ctx = ctx.withPos(BlockPos.of(tag.getLong("pos")));
@@ -128,7 +149,7 @@ public record SpoilContext(@Nullable Level level,
         }
         if (tag.contains("handlerSource")) {
             ctx = ctx.withItemHandlerSource(
-                    ItemHandlerSource.getById(new ResourceLocation(tag.getString("handlerSource"))));
+                    ItemHandlerSource.getById(ResourceLocation.parse(tag.getString("handlerSource"))));
         }
         if (tag.contains("handlerData")) {
             ctx = ctx.withItemHandlerData(tag.getCompound("handlerData"));

--- a/src/main/java/com/gregtechceu/gtceu/api/item/component/SpoilContext.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/component/SpoilContext.java
@@ -176,11 +176,11 @@ public record SpoilContext(@Nullable Level level,
 
             @Override
             protected @Nullable IItemHandler getHandler(SpoilContext ctx) {
-                if (ctx.level() == null || ctx.pos() == null || ctx.itemHandlerData() == null) return null;
+                if (ctx.level() == null || ctx.pos() == null) return null;
                 CompoundTag tag = ctx.itemHandlerData();
                 BlockEntity blockEntity = ctx.level().getBlockEntity(ctx.pos());
                 if (blockEntity == null) return null;
-                if (!tag.contains("side"))
+                if (tag == null || !tag.contains("side"))
                     return blockEntity.getCapability(ForgeCapabilities.ITEM_HANDLER, null).resolve().orElse(null);
                 return blockEntity
                         .getCapability(ForgeCapabilities.ITEM_HANDLER, Direction.byName(tag.getString("side")))

--- a/src/main/java/com/gregtechceu/gtceu/api/item/component/SpoilContext.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/component/SpoilContext.java
@@ -223,5 +223,15 @@ public record SpoilContext(@Nullable Level level,
         }
 
         abstract protected @Nullable IItemHandler getHandler(SpoilContext ctx);
+
+        public static ItemHandlerSource temp(IItemHandler handler) {
+            return new ItemHandlerSource(GTCEu.id("temp")) {
+
+                @Override
+                protected @Nullable IItemHandler getHandler(SpoilContext ctx) {
+                    return handler;
+                }
+            };
+        }
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/item/component/SpoilContext.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/component/SpoilContext.java
@@ -211,7 +211,8 @@ public record SpoilContext(@Nullable Level level,
 
         public ItemHandlerSource(ResourceLocation id) {
             this.id = id;
-            HANDLER_SOURCES.put(id, this);
+            if (id != null)
+                HANDLER_SOURCES.put(id, this);
         }
 
         private ResourceLocation getId() {

--- a/src/main/java/com/gregtechceu/gtceu/api/item/component/SpoilContext.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/component/SpoilContext.java
@@ -117,7 +117,8 @@ public record SpoilContext(@Nullable Level level,
         if (pos != null) tag.putLong("pos", pos.asLong());
         if (entity != null) tag.putInt("entity", entity.getId());
         if (slot != -1) tag.putInt("slot", slot);
-        if (itemHandlerSource != null) tag.putString("handlerSource", itemHandlerSource.getId().toString());
+        if (itemHandlerSource != null && itemHandlerSource.getId() != null)
+            tag.putString("handlerSource", itemHandlerSource.getId().toString());
         if (itemHandlerData != null) tag.put("handlerData", itemHandlerData);
         return tag;
     }
@@ -225,7 +226,7 @@ public record SpoilContext(@Nullable Level level,
         abstract protected @Nullable IItemHandler getHandler(SpoilContext ctx);
 
         public static ItemHandlerSource temp(IItemHandler handler) {
-            return new ItemHandlerSource(GTCEu.id("temp")) {
+            return new ItemHandlerSource(null) {
 
                 @Override
                 protected @Nullable IItemHandler getHandler(SpoilContext ctx) {

--- a/src/main/java/com/gregtechceu/gtceu/api/item/component/SpoilContext.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/component/SpoilContext.java
@@ -3,6 +3,7 @@ package com.gregtechceu.gtceu.api.item.component;
 import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.transfer.item.CustomItemStackHandler;
+import com.gregtechceu.gtceu.api.transfer.item.EntitySlotInvWrapper;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
@@ -200,6 +201,16 @@ public record SpoilContext(@Nullable Level level,
                 if (ctx.entity instanceof Player player) {
                     return new CustomItemStackHandler(player.getInventory().items);
                 } else return null;
+            }
+        };
+
+        public static final ItemHandlerSource ENTITY_INVENTORY = new ItemHandlerSource(GTCEu.id("entity_inventory")) {
+
+            @Override
+            protected @Nullable IItemHandler getHandler(SpoilContext ctx) {
+                if (ctx.entity != null)
+                    return new EntitySlotInvWrapper(ctx.entity);
+                return null;
             }
         };
 

--- a/src/main/java/com/gregtechceu/gtceu/api/transfer/item/EntitySlotInvWrapper.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/transfer/item/EntitySlotInvWrapper.java
@@ -1,0 +1,65 @@
+package com.gregtechceu.gtceu.api.transfer.item;
+
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.SlotAccess;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.items.IItemHandlerModifiable;
+
+import org.jetbrains.annotations.NotNull;
+
+public class EntitySlotInvWrapper implements IItemHandlerModifiable {
+
+    private final Entity entity;
+
+    public EntitySlotInvWrapper(Entity entity) {
+        this.entity = entity;
+    }
+
+    @Override
+    public void setStackInSlot(int slot, @NotNull ItemStack stack) {
+        entity.getSlot(slot).set(stack);
+    }
+
+    @Override
+    public int getSlots() {
+        return 0;
+    }
+
+    @Override
+    public @NotNull ItemStack getStackInSlot(int slot) {
+        return entity.getSlot(slot).get();
+    }
+
+    @Override
+    public @NotNull ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate) {
+        ItemStack existing = entity.getSlot(slot).get();
+        if (ItemStack.isSameItemSameTags(stack, existing)) {
+            int maxInserted = existing.getMaxStackSize() - existing.getCount();
+            int inserted = Math.min(maxInserted, stack.getCount());
+            if (!simulate) {
+                boolean success = entity.getSlot(slot).set(existing.copyWithCount(existing.getCount() + inserted));
+                if (!success) return stack;
+            }
+            return stack.copyWithCount(stack.getCount() - inserted);
+        }
+        return stack;
+    }
+
+    @Override
+    public @NotNull ItemStack extractItem(int slot, int amount, boolean simulate) {
+        ItemStack stack = entity.getSlot(slot).get();
+        if (!simulate)
+            setStackInSlot(slot, ItemStack.EMPTY);
+        return stack;
+    }
+
+    @Override
+    public int getSlotLimit(int slot) {
+        return entity.getSlot(slot).get().getMaxStackSize();
+    }
+
+    @Override
+    public boolean isItemValid(int slot, @NotNull ItemStack stack) {
+        return entity.getSlot(slot) != SlotAccess.NULL;
+    }
+}

--- a/src/main/java/com/gregtechceu/gtceu/common/CommonEventListener.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/CommonEventListener.java
@@ -16,6 +16,8 @@ import com.gregtechceu.gtceu.api.data.medicalcondition.MedicalCondition;
 import com.gregtechceu.gtceu.api.data.medicalcondition.Symptom;
 import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
 import com.gregtechceu.gtceu.api.item.armor.ArmorComponentItem;
+import com.gregtechceu.gtceu.api.item.component.SpoilContext;
+import com.gregtechceu.gtceu.api.item.component.SpoilUtils;
 import com.gregtechceu.gtceu.api.item.tool.GTToolType;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;
@@ -53,11 +55,13 @@ import com.gregtechceu.gtceu.integration.map.WaypointManager;
 import com.gregtechceu.gtceu.integration.map.cache.server.ServerCache;
 import com.gregtechceu.gtceu.utils.TaskHandler;
 
+import net.minecraft.client.gui.screens.inventory.CreativeModeInventoryScreen;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.Container;
 import net.minecraft.world.Difficulty;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.Entity;
@@ -67,6 +71,9 @@ import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.monster.Zombie;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.InventoryMenu;
+import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
@@ -93,6 +100,7 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.items.wrapper.InvWrapper;
 import net.minecraftforge.registries.MissingMappingsEvent;
 
 import com.tterrag.registrate.util.entry.BlockEntry;
@@ -690,6 +698,26 @@ public class CommonEventListener {
                     }
                 }
             });
+        }
+    }
+
+    @SubscribeEvent
+    public static void whileContainerOpen(TickEvent.PlayerTickEvent event) {
+        AbstractContainerMenu menu = event.player.containerMenu;
+        if (GTCEu.isClientThread() && menu instanceof CreativeModeInventoryScreen.ItemPickerMenu) return;
+        if (menu instanceof InventoryMenu) return;
+
+        for (Slot slot : menu.slots) {
+            int index = slot.getSlotIndex();
+            Container container = slot.container;
+            SpoilContext ctx = SpoilContext.EMPTY
+                    .withSlot(index)
+                    .withItemHandlerSource(SpoilContext.ItemHandlerSource.temp(new InvWrapper(container)));
+            if (container instanceof BlockEntity blockEntity) {
+                ctx = ctx.withPos(blockEntity.getBlockPos())
+                        .withLevel(blockEntity.getLevel());
+            }
+            SpoilUtils.update(slot.getItem(), ctx);
         }
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/item/SpoilableItemStack.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/SpoilableItemStack.java
@@ -4,7 +4,6 @@ import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.capability.GTCapability;
 import com.gregtechceu.gtceu.api.capability.GTCapabilityHelper;
 import com.gregtechceu.gtceu.api.item.IMergeableNBTSerializable;
-import com.gregtechceu.gtceu.api.item.ISpoilableItemStackExtension;
 import com.gregtechceu.gtceu.api.item.component.*;
 import com.gregtechceu.gtceu.common.item.behavior.SpoilableBehavior;
 import com.gregtechceu.gtceu.utils.FormattingUtil;
@@ -25,11 +24,11 @@ import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.common.util.INBTSerializable;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.event.AttachCapabilitiesEvent;
+import net.minecraftforge.items.IItemHandlerModifiable;
 
 import it.unimi.dsi.fastutil.ints.IntIntPair;
 import lombok.Getter;
 import lombok.Setter;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -115,20 +114,28 @@ public abstract class SpoilableItemStack implements ISpoilableItem, IAddInformat
             long spoilTicks = this.getSpoilTicks();
             long timeDifference = level.getGameTime() - creationTick - spoilTicks;
             if (timeDifference >= 0) {
-                ItemStack newStack = this.spoilResult(getSpoilContext(), GTCEu.isClientThread());
-                ((ISpoilableItemStackExtension) (Object) stack).gtceu$setStack(newStack);
-                onItemChanged();
-                ISpoilableItem newSpoilable = GTCapabilityHelper.getSpoilable(stack);
-                if (newSpoilable != null) {
-                    newSpoilable.setCreationTick(level.getGameTime() - timeDifference);
-                    try {
-                        newSpoilable.updateFreshness(spoilContext, false);
-                    } catch (StackOverflowError ignored) {
-                        // if items spoil in a giant chain or a loop
+                int slot = getSpoilContext().slot();
+                if (getSpoilContext().itemHandler() instanceof IItemHandlerModifiable handler &&
+                        handler.getStackInSlot(slot) == stack) {
+                    ItemStack newStack = this.spoilResult(getSpoilContext(), GTCEu.isClientThread());
+                    handler.setStackInSlot(slot, newStack);
+                    ISpoilableItem newSpoilable = GTCapabilityHelper.getSpoilable(newStack);
+                    if (newSpoilable != null) {
+                        newSpoilable.setCreationTick(level.getGameTime() - timeDifference);
+                        try {
+                            newSpoilable.updateFreshness(spoilContext, false);
+                        } catch (StackOverflowError ignored) {
+                            // if items spoil in a giant chain or a loop
+                        }
                     }
                 }
             }
         }
+    }
+
+    @Override
+    public boolean shouldHaveSpoiled() {
+        return getTicksUntilSpoiled() <= 0;
     }
 
     @Override
@@ -183,6 +190,12 @@ public abstract class SpoilableItemStack implements ISpoilableItem, IAddInformat
     @Override
     public void appendHoverText(ItemStack stack, @Nullable Level level, List<Component> tooltipComponents,
                                 TooltipFlag isAdvanced) {
+        if (shouldHaveSpoiled()) {
+            tooltipComponents.add(Component.translatable(
+                    "gtceu.tooltip.spoiled_time_ago",
+                    Component.literal(FormattingUtil.formatTime(-getTicksUntilSpoiled()))
+                            .withStyle(ChatFormatting.RED)));
+        }
         tooltipComponents.add(Component.translatable(
                 "gtceu.tooltip.spoil_time_remaining",
                 Component.literal(FormattingUtil.formatTime(getTicksUntilSpoiled()))
@@ -219,6 +232,8 @@ public abstract class SpoilableItemStack implements ISpoilableItem, IAddInformat
 
     @Override
     public int getBarColor(ItemStack stack) {
+        if (shouldHaveSpoiled())
+            return FastColor.ARGB32.color(255, 255, 0, 0);
         return FastColor.ARGB32.color(255, 255, 255, 255);
     }
 
@@ -234,6 +249,8 @@ public abstract class SpoilableItemStack implements ISpoilableItem, IAddInformat
 
     @Override
     public float getDurabilityForDisplay(ItemStack stack) {
+        if (shouldHaveSpoiled())
+            return 1;
         return (float) getTicksUntilSpoiled() / getSpoilTicks();
     }
 
@@ -291,12 +308,7 @@ public abstract class SpoilableItemStack implements ISpoilableItem, IAddInformat
     }
 
     @Override
-    public @NotNull <T> LazyOptional<T> getCapability(@NotNull Capability<T> cap, @Nullable Direction side) {
+    public <T> LazyOptional<T> getCapability(Capability<T> cap, @Nullable Direction side) {
         return GTCapability.CAPABILITY_SPOILABLE_ITEM.orEmpty(cap, LazyOptional.of(() -> this));
     }
-
-    /**
-     * Called when the stack has spoiled and transformed into a different item.
-     */
-    protected void onItemChanged() {}
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/item/SpoilableItemStack.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/SpoilableItemStack.java
@@ -305,6 +305,7 @@ public abstract class SpoilableItemStack implements ISpoilableItem, IAddInformat
                 this.setCreationTick(average);
                 spoilable.setCreationTick(average);
             }
+            spoilable.setSpoilContext(spoilContext);
         }
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/common/item/SpoilableItemStack.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/SpoilableItemStack.java
@@ -195,11 +195,12 @@ public abstract class SpoilableItemStack implements ISpoilableItem, IAddInformat
                     "gtceu.tooltip.spoiled_time_ago",
                     Component.literal(FormattingUtil.formatTime(-getTicksUntilSpoiled()))
                             .withStyle(ChatFormatting.RED)));
+        } else {
+            tooltipComponents.add(Component.translatable(
+                    "gtceu.tooltip.spoil_time_remaining",
+                    Component.literal(FormattingUtil.formatTime(getTicksUntilSpoiled()))
+                            .withStyle(ChatFormatting.DARK_AQUA)));
         }
-        tooltipComponents.add(Component.translatable(
-                "gtceu.tooltip.spoil_time_remaining",
-                Component.literal(FormattingUtil.formatTime(getTicksUntilSpoiled()))
-                        .withStyle(ChatFormatting.DARK_AQUA)));
         tooltipComponents.add(Component.translatable(
                 "gtceu.tooltip.spoils_into", getSpoilResultTooltip()));
         if (isAdvanced.isAdvanced()) {

--- a/src/main/java/com/gregtechceu/gtceu/common/item/SpoilableItemStack.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/SpoilableItemStack.java
@@ -72,7 +72,7 @@ public abstract class SpoilableItemStack implements ISpoilableItem, IAddInformat
     private long creationTick = 0;
     @Getter
     @Setter
-    private SpoilContext spoilContext = new SpoilContext();
+    private SpoilContext spoilContext = SpoilContext.EMPTY;
 
     public SpoilableItemStack(ItemStack stack) {
         this.stack = stack;
@@ -133,7 +133,7 @@ public abstract class SpoilableItemStack implements ISpoilableItem, IAddInformat
 
     @Override
     public long getTicksUntilSpoiled() {
-        updateFreshness(new SpoilContext(), false);
+        updateFreshness(SpoilContext.EMPTY, false);
         if (!initialized) return this.getSpoilTicks();
         if (frozen) return frozenTicks;
         Level level = SpoilContext.getDefaultLevel();
@@ -146,7 +146,7 @@ public abstract class SpoilableItemStack implements ISpoilableItem, IAddInformat
 
     @Override
     public void setTicksUntilSpoiled(long value) {
-        updateFreshness(new SpoilContext(), false);
+        updateFreshness(SpoilContext.EMPTY, false);
         Level level = SpoilContext.getDefaultLevel();
         if (level != null && initialized)
             setCreationTick(level.getGameTime() - this.getSpoilTicks() + value);
@@ -154,7 +154,7 @@ public abstract class SpoilableItemStack implements ISpoilableItem, IAddInformat
 
     private void setFreezeSpoiling(boolean freeze) {
         if (freeze) {
-            updateFreshness(new SpoilContext(), true);
+            updateFreshness(SpoilContext.EMPTY, true);
             frozenTicks = getTicksUntilSpoiled();
             frozen = true;
         } else {
@@ -214,7 +214,7 @@ public abstract class SpoilableItemStack implements ISpoilableItem, IAddInformat
     }
 
     protected Component getSpoilResultTooltip() {
-        return spoilResult(new SpoilContext(), false).getDisplayName();
+        return spoilResult(SpoilContext.EMPTY, false).getDisplayName();
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/InvWrapperMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/InvWrapperMixin.java
@@ -30,7 +30,7 @@ public abstract class InvWrapperMixin {
 
     @Unique
     private SpoilContext gtceu$getSpoilContext() {
-        SpoilContext ctx = new SpoilContext();
+        SpoilContext ctx = SpoilContext.EMPTY;
         if (inv instanceof BlockEntity blockEntity) {
             return ctx
                     .withLevel(blockEntity.getLevel())

--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/ItemStackMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/ItemStackMixin.java
@@ -12,6 +12,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.util.FastColor;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.TooltipFlag;
@@ -28,9 +29,14 @@ import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 @Mixin(ItemStack.class)
 public abstract class ItemStackMixin {
 
+    @Shadow
+    @Nullable
+    private Entity entityRepresentation;
     /**
      * Whether {@link ItemStackMixin#gtceu$updateFreshness(SpoilContext, boolean)}
      * was called and did not return yet.
@@ -61,6 +67,16 @@ public abstract class ItemStackMixin {
             gtceu$self().getCapability(GTCapability.CAPABILITY_SPOILABLE_ITEM)
                     .ifPresent(spoilable -> spoilable.updateFreshness(spoilContext, createTag));
             gtceu$isUpdating = false;
+        }
+    }
+
+    @Inject(at = @At("HEAD"), method = "getItem")
+    private void gtceu$updateFreshnessOnGet(CallbackInfoReturnable<Item> cir) {
+        if (entityRepresentation != null) {
+            gtceu$updateFreshness(new SpoilContext(entityRepresentation)
+                    .withItemHandlerSource(SpoilContext.ItemHandlerSource.ENTITY_INVENTORY), true);
+        } else {
+            gtceu$updateFreshness(SpoilContext.EMPTY, false);
         }
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/ItemStackMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/ItemStackMixin.java
@@ -120,7 +120,7 @@ public abstract class ItemStackMixin implements ISpoilableItemStackExtension {
     private void gtceu$injectedFreshnessUpdate(CallbackInfoReturnable<Item> cir) {
         if (gtceu$self().getEntityRepresentation() != null)
             gtceu$updateFreshness(new SpoilContext(gtceu$self().getEntityRepresentation()), true);
-        else gtceu$updateFreshness(new SpoilContext(), false);
+        else gtceu$updateFreshness(SpoilContext.EMPTY, false);
     }
 
     @Inject(at = @At("HEAD"), method = "inventoryTick")

--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/ItemStackMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/ItemStackMixin.java
@@ -3,24 +3,20 @@ package com.gregtechceu.gtceu.core.mixins;
 import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.capability.GTCapability;
 import com.gregtechceu.gtceu.api.capability.GTCapabilityHelper;
-import com.gregtechceu.gtceu.api.item.ISpoilableItemStackExtension;
 import com.gregtechceu.gtceu.api.item.component.*;
 import com.gregtechceu.gtceu.utils.FormattingUtil;
 
 import net.minecraft.ChatFormatting;
-import net.minecraft.core.Holder;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.util.FastColor;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.ItemLike;
 import net.minecraft.world.level.Level;
-import net.minecraftforge.registries.ForgeRegistries;
 
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.asm.mixin.*;
@@ -32,39 +28,9 @@ import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 import java.util.List;
 
-import javax.annotation.Nullable;
-
 @Mixin(ItemStack.class)
-public abstract class ItemStackMixin implements ISpoilableItemStackExtension {
+public abstract class ItemStackMixin {
 
-    // ************************* //
-    // Shadow fields and methods //
-    // ************************* //
-
-    @Shadow
-    @Mutable
-    @Final
-    @Nullable
-    private Item item;
-
-    @Shadow(remap = false)
-    @Mutable
-    @Final
-    @Nullable
-    private Holder.Reference<Item> delegate;
-
-    @Shadow(remap = false)
-    protected abstract void forgeInit();
-
-    // ************* //
-    // Unique fields //
-    // ************* //
-
-    @Shadow
-    @Nullable
-    private CompoundTag tag;
-    @Shadow
-    private int count;
     /**
      * Whether {@link ItemStackMixin#gtceu$updateFreshness(SpoilContext, boolean)}
      * was called and did not return yet.
@@ -88,20 +54,6 @@ public abstract class ItemStackMixin implements ISpoilableItemStackExtension {
         return (ItemStack) (Object) this;
     }
 
-    // ************************* //
-    // Interface implementations //
-    // ************************* //
-
-    @Unique
-    @Override
-    public void gtceu$setStack(ItemStack newStack) {
-        item = newStack.getItem();
-        delegate = ForgeRegistries.ITEMS.getDelegateOrThrow(item);
-        count = newStack.getCount();
-        tag = newStack.getTag();
-        forgeInit();
-    }
-
     @Unique
     public void gtceu$updateFreshness(@NotNull SpoilContext spoilContext, boolean createTag) {
         if (!gtceu$isUpdating) {
@@ -110,17 +62,6 @@ public abstract class ItemStackMixin implements ISpoilableItemStackExtension {
                     .ifPresent(spoilable -> spoilable.updateFreshness(spoilContext, createTag));
             gtceu$isUpdating = false;
         }
-    }
-
-    // ********* //
-    // Injectors //
-    // ********* //
-
-    @Inject(at = @At("HEAD"), method = { "getItem", "getCount" })
-    private void gtceu$injectedFreshnessUpdate(CallbackInfoReturnable<Item> cir) {
-        if (gtceu$self().getEntityRepresentation() != null)
-            gtceu$updateFreshness(new SpoilContext(gtceu$self().getEntityRepresentation()), true);
-        else gtceu$updateFreshness(SpoilContext.EMPTY, false);
     }
 
     @Inject(at = @At("HEAD"), method = "inventoryTick")

--- a/src/main/java/com/gregtechceu/gtceu/data/lang/LangHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/lang/LangHandler.java
@@ -1900,6 +1900,8 @@ public class LangHandler {
         provider.add("gtceu.tooltip.player_bind", "Bound to player: %s");
         provider.add("gtceu.gui.item_collector.range", "Range: ");
         provider.add("gtceu.tooltip.spoil_time_remaining", "Time until spoils: %s");
+        provider.add("gtceu.tooltip.spoiled_time_ago",
+                "This item will transform upon entering a supported inventory!\nSpoiled %s ago.");
         provider.add("gtceu.tooltip.spoil_time_total", "Total spoil time: %s");
         provider.add("gtceu.tooltip.spoils_into", "Spoils into: %s");
         provider.add("gtceu.tooltip.creation_tick", "Created on overworld tick %d");

--- a/src/main/java/com/gregtechceu/gtceu/data/lang/LangHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/lang/LangHandler.java
@@ -1901,7 +1901,7 @@ public class LangHandler {
         provider.add("gtceu.gui.item_collector.range", "Range: ");
         provider.add("gtceu.tooltip.spoil_time_remaining", "Time until spoils: %s");
         provider.add("gtceu.tooltip.spoiled_time_ago",
-                "This item will transform upon entering a supported inventory!\nSpoiled %s ago.");
+                "§bThis item will transform upon entering a supported inventory!§r\nSpoiled %s ago");
         provider.add("gtceu.tooltip.spoil_time_total", "Total spoil time: %s");
         provider.add("gtceu.tooltip.spoils_into", "Spoils into: %s");
         provider.add("gtceu.tooltip.creation_tick", "Created on overworld tick %d");

--- a/src/main/java/com/gregtechceu/gtceu/utils/FormattingUtil.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/FormattingUtil.java
@@ -257,7 +257,7 @@ public class FormattingUtil {
         if (sec >= 60) out = ((sec / 60) % 60) + "m " + out;
         if (sec >= 3600) out = ((sec / 3600) % 24) + "h " + out;
         if (sec >= 24 * 3600) out = (sec / (3600 * 24)) + "d " + out;
-        return out;
+        return out.trim();
     }
 
     @NotNull

--- a/src/test/java/com/gregtechceu/gtceu/common/item/SpoilableBehaviourTest.java
+++ b/src/test/java/com/gregtechceu/gtceu/common/item/SpoilableBehaviourTest.java
@@ -200,7 +200,7 @@ public class SpoilableBehaviourTest {
         TestUtils.succeedAfterTest(helper);
         BusHolder busHolder = getBussesAndForm(helper);
         ItemStack input = new ItemStack(Items.JIGSAW);
-        SpoilUtils.update(input, new SpoilContext());
+        SpoilUtils.update(input, SpoilContext.EMPTY);
         Objects.requireNonNull(GTCapabilityHelper.getSpoilable(input)).setTicksUntilSpoiled(8);
         busHolder.inputBus1.getInventory().setStackInSlot(0, input);
         helper.runAtTickTime(21, () -> {
@@ -222,7 +222,7 @@ public class SpoilableBehaviourTest {
         TestUtils.succeedAfterTest(helper);
         BusHolder busHolder = getBussesAndForm(helper);
         ItemStack input = new ItemStack(Items.APPLE);
-        SpoilUtils.update(input, new SpoilContext());
+        SpoilUtils.update(input, SpoilContext.EMPTY);
         Objects.requireNonNull(GTCapabilityHelper.getSpoilable(input)).setTicksUntilSpoiled(8);
         busHolder.inputBus1.getInventory().setStackInSlot(0, input);
         helper.runAtTickTime(21, () -> {
@@ -291,8 +291,8 @@ public class SpoilableBehaviourTest {
         TestUtils.succeedAfterTest(helper);
         ItemStack stack1 = Items.JIGSAW.getDefaultInstance().copyWithCount(9);
         ItemStack stack2 = Items.JIGSAW.getDefaultInstance().copyWithCount(5);
-        SpoilUtils.update(stack1, new SpoilContext());
-        SpoilUtils.update(stack2, new SpoilContext());
+        SpoilUtils.update(stack1, SpoilContext.EMPTY);
+        SpoilUtils.update(stack2, SpoilContext.EMPTY);
         ISpoilableItem spoilable1 = GTCapabilityHelper.getSpoilable(stack1);
         ISpoilableItem spoilable2 = GTCapabilityHelper.getSpoilable(stack2);
         TestUtils.assertNotNull(helper, spoilable1, "spoilable1 was null");


### PR DESCRIPTION
## What
 - Remove spoilage's ability to modify the stack in-place
 - Remove updating the stack in `getItem` and `getCount` through a mixin
 - Update stacks every tick while a container is open
 - Make spoilage work on servers

No AI.

## How was this tested
In-game. Please note that currently half the spoilage tests on this are failing and idk if i wanna fix them rn considering i have an another pr open that switches out all the items used in these tests

## Outcome
make some people happy and fix some potential issues
