### PR TITLE
Fix Recipes with null ID's Crashing the Game

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/lookup/RecipeManagerHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/lookup/RecipeManagerHandler.java
@@ -59,6 +59,7 @@ public final class RecipeManagerHandler {
                 continue;
             }
             if (r.value() instanceof GTRecipe recipe) {
+                recipe.setId(r.id());
                 lookup.addStaging(recipe);
             }
         }


### PR DESCRIPTION
## What
Recipes did not have their ID inserted into their holder, this would cause reading of null values which would NPE the game over null ID's


## Implementation Details
passing the id of the recipeHolder into the GT Recipe inside of said holder

### AI Usage 
no

## Outcome
Less game explody

## How Was This Tested
Frontiert, the game loaded and recipes didn't blackhole the game or themselves

## Additional Information
this PR was arguably the hardest thing ever because my cat was infront of my face.

## Potential Compatibility Issues
none probably
