### PR TITLE
Fix Overlays for Inworld and SchemaWorld Previews

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -142,6 +142,9 @@ dependencies {
         transitive = false
     }
 
+    extraLocalRuntime(forge.kotlinforforge) {
+        transitive = false
+    }
     extraLocalRuntime(forge.observable)
     //////////////////////////
 

--- a/gradle/forge.versions.toml
+++ b/gradle/forge.versions.toml
@@ -11,6 +11,7 @@ create = "6.0.10-281"
 ponder = "1.0.64"
 flywheel = "1.0.5"
 curios = "9.4.2+1.21.1"
+kotlinforforge = "5.7.0"
 journeyMapApi = "2.0.0-1.21.1-SNAPSHOT"
 ftblibrary = "2101.1.30"
 ftbteams = "2101.1.9"
@@ -72,6 +73,7 @@ ponder              = { module = "net.createmod.ponder:Ponder-NeoForge-1.21.1", 
 flywheel-api        = { module = "dev.engine-room.flywheel:flywheel-neoforge-api-1.21.1", version.ref = "flywheel" }
 flywheel            = { module = "dev.engine-room.flywheel:flywheel-neoforge-1.21.1", version.ref = "flywheel" }
 curios              = { module = "top.theillusivec4.curios:curios-neoforge", version.ref = "curios" }
+kotlinforforge      = { module = "thedarkcolour:kotlinforforge-neoforge", version.ref = "kotlinforforge" }
 journeymap-api      = { module = "info.journeymap:journeymap-api-neoforge", version.ref = "journeyMapApi" }
 ftblibrary          = { module = "dev.ftb.mods:ftb-library-neoforge", version.ref = "ftblibrary" }
 ftbteams            = { module = "dev.ftb.mods:ftb-teams-neoforge", version.ref = "ftbteams" }

--- a/gradle/scripts/repositories.gradle
+++ b/gradle/scripts/repositories.gradle
@@ -95,6 +95,10 @@ repositories {
         forRepository { maven { url = "https://maven.theillusivec4.top/" } }
         filter { includeGroup('top.theillusivec4.curios')}
     }
+    exclusiveContent { // KotlinForForge
+        forRepository { maven { url = "https://thedarkcolour.github.io/KotlinForForge/" } }
+        filter { includeGroup("thedarkcolour") }
+    }
     exclusiveContent { // Argonauts, Heracles
         forRepository { maven { url = "https://maven.teamresourceful.com/repository/maven-public/" } }
         filter {

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/CustomChunkRenderPassRegistry.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/CustomChunkRenderPassRegistry.java
@@ -32,9 +32,16 @@ public final class CustomChunkRenderPassRegistry {
     private static final List<CustomChunkRenderPass> ACTIVE_PASSES = PASSES.stream()
             .filter(pass -> pass.loadCondition().getAsBoolean())
             .toList();
+    private static final List<CustomChunkRenderPass> AFTER_CUTOUT_PASSES = ACTIVE_PASSES.stream()
+            .filter(pass -> pass.drawStage() == CustomChunkRenderPass.DrawStage.AFTER_CUTOUT)
+            .toList();
 
     public static List<CustomChunkRenderPass> activePasses() {
         return ACTIVE_PASSES;
+    }
+
+    public static List<CustomChunkRenderPass> afterCutoutPasses() {
+        return AFTER_CUTOUT_PASSES;
     }
 
     public static @Nullable CustomChunkRenderPass getPass(RenderType renderType) {
@@ -51,9 +58,7 @@ public final class CustomChunkRenderPassRegistry {
         if (event.getStage() != RenderLevelStageEvent.Stage.AFTER_CUTOUT_BLOCKS) return;
 
         var cameraPosition = event.getCamera().getPosition();
-        for (CustomChunkRenderPass pass : ACTIVE_PASSES) {
-            if (pass.drawStage() != CustomChunkRenderPass.DrawStage.AFTER_CUTOUT) continue;
-
+        for (CustomChunkRenderPass pass : AFTER_CUTOUT_PASSES) {
             ((LevelRendererAccessor) event.getLevelRenderer()).invokeRenderSectionLayer(pass.renderType(),
                     cameraPosition.x, cameraPosition.y, cameraPosition.z,
                     event.getModelViewMatrix(), event.getProjectionMatrix());

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/PatternPreviewRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/PatternPreviewRenderer.java
@@ -52,12 +52,7 @@ public class PatternPreviewRenderer {
 
     public static final PatternPreviewRenderer INSTANCE = new PatternPreviewRenderer();
 
-    private static final Map<RenderLevelStageEvent.Stage, RenderType> STAGE_RENDER_TYPES = Util
-            .make(new IdentityHashMap<>(), map -> {
-                for (RenderType renderType : RenderType.chunkBufferLayers()) {
-                    map.put(RenderLevelStageEvent.Stage.fromRenderType(renderType), renderType);
-                }
-            });
+    private static final Map<RenderLevelStageEvent.Stage, List<RenderType>> STAGE_RENDER_TYPES = createStageRenderTypes();
 
     private @Nullable MutableSchema schema;
     private @Nullable RenderLevel renderLevel;
@@ -121,22 +116,40 @@ public class PatternPreviewRenderer {
         if (this.schema == null || this.controllerPos == null) return;
         if (!camera.isInitialized()) return;
 
-        RenderType renderType = STAGE_RENDER_TYPES.get(stage);
-        if (renderType == null && stage != RenderLevelStageEvent.Stage.AFTER_BLOCK_ENTITIES) return;
+        List<RenderType> renderTypes = STAGE_RENDER_TYPES.get(stage);
+        if (renderTypes == null && stage != RenderLevelStageEvent.Stage.AFTER_BLOCK_ENTITIES) return;
 
         poseStack.pushPose();
         poseStack.translate(controllerPos.getX(), controllerPos.getY(), controllerPos.getZ());
 
         Vec3 cameraPos = camera.getPosition();
-        if (renderType != null) {
-            // render the appropriate chunk layer if renderType is a chunk render layer
-            renderBlocks(renderType, cameraPos, modelViewMatrix);
+        if (renderTypes != null) {
+            for (RenderType renderType : renderTypes) {
+                renderBlocks(renderType, cameraPos, modelViewMatrix);
+            }
         } else {
-            // render block entities if renderType==null
             renderBlockEntities(poseStack, bufferSource, partialTick, cameraPos);
         }
 
         poseStack.popPose();
+    }
+
+    private static Map<RenderLevelStageEvent.Stage, List<RenderType>> createStageRenderTypes() {
+        Map<RenderLevelStageEvent.Stage, List<RenderType>> renderTypes = new IdentityHashMap<>();
+        for (RenderType renderType : RenderType.chunkBufferLayers()) {
+            if (CustomChunkRenderPassRegistry.getPass(renderType) != null) continue;
+
+            RenderLevelStageEvent.Stage stage = RenderLevelStageEvent.Stage.fromRenderType(renderType);
+            if (stage != null) {
+                renderTypes.computeIfAbsent(stage, ignored -> new ArrayList<>()).add(renderType);
+            }
+        }
+        List<RenderType> afterCutout = renderTypes.computeIfAbsent(
+                RenderLevelStageEvent.Stage.AFTER_CUTOUT_BLOCKS, ignored -> new ArrayList<>());
+        for (CustomChunkRenderPass pass : CustomChunkRenderPassRegistry.afterCutoutPasses()) {
+            afterCutout.add(pass.renderType());
+        }
+        return renderTypes;
     }
 
     public void notifyRecompile() {

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTSoundEntries.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTSoundEntries.java
@@ -4,6 +4,7 @@ import com.gregtechceu.gtceu.api.registry.GTRegistries;
 import com.gregtechceu.gtceu.api.sound.SoundEntry;
 
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.neoforge.registries.RegisterEvent;
@@ -59,6 +60,8 @@ public class GTSoundEntries {
 
     @SubscribeEvent
     private static void registerSounds(RegisterEvent event) {
+        if (event.getRegistryKey() != Registries.SOUND_EVENT) return;
+
         for (SoundEntry entry : GTRegistries.SOUNDS) {
             entry.prepare();
             entry.register(soundEvent -> GTRegistries.register(BuiltInRegistries.SOUND_EVENT, soundEvent.getLocation(),

--- a/src/main/java/com/gregtechceu/gtceu/integration/recipeviewer/widgets/GTMultiblockSchemaRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/recipeviewer/widgets/GTMultiblockSchemaRenderer.java
@@ -1,0 +1,25 @@
+package com.gregtechceu.gtceu.integration.recipeviewer.widgets;
+
+import com.gregtechceu.gtceu.client.renderer.CustomChunkRenderPassRegistry;
+
+import net.minecraft.client.renderer.RenderType;
+
+import brachy.modularui.drawable.SchemaRenderer;
+import brachy.modularui.drawable.schema.ISchema;
+
+public class GTMultiblockSchemaRenderer extends SchemaRenderer {
+
+    public GTMultiblockSchemaRenderer(ISchema schema) {
+        super(schema);
+    }
+
+    @Override
+    protected void renderBlocks(RenderCompileResults renderResult, RenderType renderType) {
+        super.renderBlocks(renderResult, renderType);
+        if (renderType != RenderType.cutout()) return;
+
+        for (var pass : CustomChunkRenderPassRegistry.afterCutoutPasses()) {
+            super.renderBlocks(renderResult, pass.renderType());
+        }
+    }
+}

--- a/src/main/java/com/gregtechceu/gtceu/integration/recipeviewer/widgets/MultiblockPreviewWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/recipeviewer/widgets/MultiblockPreviewWidget.java
@@ -28,7 +28,6 @@ import brachy.modularui.api.drawable.Text;
 import brachy.modularui.api.widget.IGuiAction;
 import brachy.modularui.drawable.Icon;
 import brachy.modularui.drawable.ItemDrawable;
-import brachy.modularui.drawable.SchemaRenderer;
 import brachy.modularui.drawable.schema.BlockHighlight;
 import brachy.modularui.integration.recipeviewer.RecipeSlotRole;
 import brachy.modularui.integration.recipeviewer.RecipeViewerSlotWidget;
@@ -99,7 +98,7 @@ public class MultiblockPreviewWidget extends ParentWidget<MultiblockPreviewWidge
         };
         this.multiblockSchemaInfo = schemaInfo == null ? new MultiblockSchemaInfo() : schemaInfo;
         refreshSchema();
-        this.multiblockSchemaInfo.setRenderer(new SchemaRenderer(this.multiblockSchemaInfo.getMapSchema())
+        this.multiblockSchemaInfo.setRenderer(new GTMultiblockSchemaRenderer(this.multiblockSchemaInfo.getMapSchema())
                 .highlightRenderer(new BlockHighlight(Color.withAlpha(Color.GREEN.brighter(1), 0.9f), 1 / 32f)));
 
         IGuiAction.MouseReleased setBlockOnClick = (ctx, m) -> {


### PR DESCRIPTION
Kotlin Exploded, fixed it because observable demands it
needed to pass stuff to the new renders yippie wahoo

yeah AI, used it to locate the broken points so i can fix them and also offered suggestions, codex-sol-5.6

This builds upon the previous overlay PR, just makes it work in EMI and In world Previews again :thumbsup:
Register sounds was crashing so fixed it as well

I'm tired I want to sleep