### PR TITLE
Re-introduce Large Turbine UI lines

### DIFF
--- a/src/generated/resources/assets/gtceu/lang/en_ud.json
+++ b/src/generated/resources/assets/gtceu/lang/en_ud.json
@@ -3552,6 +3552,7 @@
   "gtceu.multiblock.turbine.energy_per_tick_maxed": "ʇ/∩Ǝ %s :ʇndʇnO ʎbɹǝuƎ",
   "gtceu.multiblock.turbine.fuel_amount": ")%s( Ꞁ%s :ʇunoɯⱯ ןǝnℲ",
   "gtceu.multiblock.turbine.fuel_needed": "sʞɔıʇ %s ɹǝd %s sǝɯnsuoƆ",
+  "gtceu.multiblock.turbine.no_rotor": "ɹoʇoᴚ buıssıW",
   "gtceu.multiblock.turbine.obstructed": "pǝʇɔnɹʇsqO ǝɔɐℲ ǝuıqɹn⟘",
   "gtceu.multiblock.turbine.rotor_durability": "%s%% :ʎʇıןıqɐɹnᗡ ɹoʇoᴚ",
   "gtceu.multiblock.turbine.rotor_speed": "WԀᴚ %s/%s :pǝǝdS ɹoʇoᴚ",

--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -3552,6 +3552,7 @@
   "gtceu.multiblock.turbine.energy_per_tick_maxed": "Energy Output: %s EU/t",
   "gtceu.multiblock.turbine.fuel_amount": "Fuel Amount: %sL (%s)",
   "gtceu.multiblock.turbine.fuel_needed": "Consumes %s per %s ticks",
+  "gtceu.multiblock.turbine.no_rotor": "Missing Rotor",
   "gtceu.multiblock.turbine.obstructed": "Turbine Face Obstructed",
   "gtceu.multiblock.turbine.rotor_durability": "Rotor Durability: %s%%",
   "gtceu.multiblock.turbine.rotor_speed": "Rotor Speed: %s/%s RPM",

--- a/src/main/java/com/gregtechceu/gtceu/common/data/machines/GTMachineUtils.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/machines/GTMachineUtils.java
@@ -737,6 +737,7 @@ public class GTMachineUtils {
                         () -> new ItemLike[] {
                                 GTMaterialItems.MATERIAL_ITEMS.get(TagPrefix.dustTiny, GTMaterials.Ash).get() })
                 .workableCasingModel(casingTexture, overlayModel)
+                .additionalDisplay(LargeTurbineMachine::additionalDisplay)
                 .tooltips(
                         Component.translatable("gtceu.universal.tooltip.base_production_eut", V[tier] * 2),
                         Component.translatable("gtceu.multiblock.turbine.efficiency_tooltip", VNF[tier]))

--- a/src/main/java/com/gregtechceu/gtceu/common/data/machines/GTMachineUtils.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/machines/GTMachineUtils.java
@@ -737,7 +737,6 @@ public class GTMachineUtils {
                         () -> new ItemLike[] {
                                 GTMaterialItems.MATERIAL_ITEMS.get(TagPrefix.dustTiny, GTMaterials.Ash).get() })
                 .workableCasingModel(casingTexture, overlayModel)
-                .additionalDisplay(LargeTurbineMachine::additionalDisplay)
                 .tooltips(
                         Component.translatable("gtceu.universal.tooltip.base_production_eut", V[tier] * 2),
                         Component.translatable("gtceu.multiblock.turbine.efficiency_tooltip", VNF[tier]))

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/generator/LargeTurbineMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/generator/LargeTurbineMachine.java
@@ -29,6 +29,7 @@ import brachy.modularui.value.sync.IntSyncValue;
 import brachy.modularui.value.sync.LongSyncValue;
 import brachy.modularui.value.sync.PanelSyncManager;
 import lombok.Getter;
+import net.minecraftforge.client.event.CustomizeGuiOverlayEvent;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
@@ -167,22 +168,26 @@ public class LargeTurbineMachine extends WorkableElectricMultiblockMachine imple
 
         var rotorSpeedDisplay = Text.dynamic(() -> Component.translatable("gtceu.multiblock.turbine.rotor_speed",
                 FormattingUtil.formatNumbers(rotorSpeed.getIntValue()),
-                FormattingUtil.formatNumbers(maxRotorSpeed.getIntValue())))
+                FormattingUtil.formatNumbers(maxRotorSpeed.getIntValue()))
+                        .setStyle(Style.EMPTY.withColor(ChatFormatting.WHITE)))
                 .asWidget()
                 .setEnabledIf(w -> true);
         var turbineEfficiencyDisplay = Text.dynamic(() -> Component.translatable("gtceu.multiblock.turbine.efficiency",
-                totalEfficiency.getIntValue()))
+                totalEfficiency.getIntValue())
+                        .setStyle(Style.EMPTY.withColor(ChatFormatting.WHITE)))
                 .asWidget()
                 .setEnabledIf(w -> true);
         var turbinePowerDisplay = Text.dynamic(() -> Component.translatable("gtceu.multiblock.turbine.energy_per_tick",
                 FormattingUtil.formatNumbers(currentOutput.getIntValue()),
-                FormattingUtil.formatNumbers(maxOutput.getIntValue())))
+                FormattingUtil.formatNumbers(maxOutput.getIntValue()))
+                .setStyle(Style.EMPTY.withColor(ChatFormatting.WHITE)))
                 .asWidget()
                 .setEnabledIf(w -> isActive.getBoolValue());
         var rotorDurabilityDisplay = Text
                 .dynamic(() -> Component.translatable("gtceu.multiblock.turbine.rotor_durability",
                         rotorDurability.getIntValue())
-                        .setStyle(rotorDurability.getIntValue() > MIN_DURABILITY_TO_WARN ? Style.EMPTY :
+                        .setStyle(rotorDurability.getIntValue() > MIN_DURABILITY_TO_WARN ?
+                                Style.EMPTY.withColor(ChatFormatting.WHITE) :
                                 Style.EMPTY.withColor(ChatFormatting.RED)))
                 .asWidget()
                 .setEnabledIf(w -> true);

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/generator/LargeTurbineMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/generator/LargeTurbineMachine.java
@@ -5,7 +5,6 @@ import com.gregtechceu.gtceu.api.blockentity.BlockEntityCreationInfo;
 import com.gregtechceu.gtceu.api.capability.recipe.RecipeCapability;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.machine.feature.ITieredMachine;
-import com.gregtechceu.gtceu.api.machine.multiblock.MultiblockControllerMachine;
 import com.gregtechceu.gtceu.api.machine.multiblock.WorkableElectricMultiblockMachine;
 import com.gregtechceu.gtceu.api.machine.multiblock.part.MultiblockPartMachine;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
@@ -15,6 +14,7 @@ import com.gregtechceu.gtceu.api.recipe.modifier.ModifierFunction;
 import com.gregtechceu.gtceu.api.recipe.modifier.ParallelLogic;
 import com.gregtechceu.gtceu.api.recipe.modifier.RecipeModifier;
 import com.gregtechceu.gtceu.common.machine.multiblock.part.RotorHolderPartMachine;
+import com.gregtechceu.gtceu.common.mui.GTMultiblockTextUtil;
 import com.gregtechceu.gtceu.utils.FormattingUtil;
 
 import net.minecraft.ChatFormatting;
@@ -31,8 +31,7 @@ import brachy.modularui.value.sync.PanelSyncManager;
 import lombok.Getter;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -132,31 +131,28 @@ public class LargeTurbineMachine extends WorkableElectricMultiblockMachine imple
     // ******* GUI ********//
     //////////////////////////////////////
 
+    @Override
+    public List<IWidget> getWidgetsForDisplay(PanelSyncManager syncManager) {
+        List<IWidget> widgets = new ArrayList<>();
 
-//    @Override
-//    public List<IWidget> getWidgetsForDisplay(PanelSyncManager syncManager) {
-//        return super.getWidgetsForDisplay(syncManager);
-//    }
+        widgets.add(GTMultiblockTextUtil.addEnergyTierLine(this, syncManager));
+        widgets.add(GTMultiblockTextUtil.addUnformedWarning(this, syncManager));
+        if (!isFormed())
+            return widgets;
 
-    public static List<IWidget> additionalDisplay(MultiblockControllerMachine controller,
-                                                  PanelSyncManager syncManager) {
-        if (!(controller instanceof LargeTurbineMachine ltMachine))
-            return Collections.emptyList();
-        if (!controller.isFormed())
-            return Collections.emptyList();
-
-        var rotorHolder = ltMachine.getRotorHolder();
+        var rotorHolder = getRotorHolder();
         if (!(rotorHolder != null && rotorHolder.hasRotor())) {
-            return Collections.singletonList(
+            widgets.add(
                     Text.dynamic(() -> (Component.translatable("gtceu.multiblock.turbine.no_rotor"))
                             .setStyle(Style.EMPTY.withColor(ChatFormatting.RED)))
                             .asWidget()
                             .setEnabledIf(w -> true));
+            return widgets;
         }
 
         BooleanSyncValue isActive = syncManager.getOrCreateSyncHandler("isActive",
                 BooleanSyncValue.class,
-                () -> new BooleanSyncValue(ltMachine::isActive));
+                () -> new BooleanSyncValue(this::isActive));
         IntSyncValue rotorSpeed = syncManager.getOrCreateSyncHandler("rotorSpeed",
                 IntSyncValue.class,
                 () -> new IntSyncValue(rotorHolder::getRotorSpeed));
@@ -168,10 +164,10 @@ public class LargeTurbineMachine extends WorkableElectricMultiblockMachine imple
                 () -> new IntSyncValue(rotorHolder::getTotalEfficiency));
         LongSyncValue currentOutput = syncManager.getOrCreateSyncHandler("currentOutput",
                 LongSyncValue.class,
-                () -> new LongSyncValue(ltMachine::getCurrentProduction));
+                () -> new LongSyncValue(this::getCurrentProduction));
         LongSyncValue maxOutput = syncManager.getOrCreateSyncHandler("maxOutput",
                 LongSyncValue.class,
-                () -> new LongSyncValue(ltMachine::getOverclockVoltage));
+                () -> new LongSyncValue(this::getOverclockVoltage));
         IntSyncValue rotorDurability = syncManager.getOrCreateSyncHandler("rotorDurability",
                 IntSyncValue.class,
                 () -> new IntSyncValue(rotorHolder::getRotorDurabilityPercent));
@@ -202,7 +198,21 @@ public class LargeTurbineMachine extends WorkableElectricMultiblockMachine imple
                 .asWidget()
                 .setEnabledIf(w -> true);
 
-        return Arrays.asList(rotorSpeedDisplay, turbineEfficiencyDisplay, turbinePowerDisplay, rotorDurabilityDisplay);
+        widgets.add(GTMultiblockTextUtil.addProgressLine(this, syncManager));
+        widgets.add(GTMultiblockTextUtil.addWorkingStatusLine(this, syncManager));
+        widgets.add(GTMultiblockTextUtil.addRecipeTypeField(this, syncManager));
+
+        widgets.add(rotorSpeedDisplay);
+        widgets.add(turbineEfficiencyDisplay);
+        widgets.add(turbinePowerDisplay);
+        widgets.add(rotorDurabilityDisplay);
+
+        widgets.addAll(getDefinition().getAdditionalDisplay().apply(this, syncManager));
+        widgets.add(GTMultiblockTextUtil.addTotalRunsLine(this, syncManager));
+        widgets.add(GTMultiblockTextUtil.addOutputLines(this, syncManager));
+        widgets.addAll(GTMultiblockTextUtil.addRecipeFailReasonLines(this, syncManager));
+
+        return widgets;
     }
 
     //////////////////////////////////////
@@ -225,13 +235,15 @@ public class LargeTurbineMachine extends WorkableElectricMultiblockMachine imple
         }
 
         var rotorHolder = turbineMachine.getRotorHolder();
-        if (rotorHolder == null) return ModifierFunction.NULL;
+        if (rotorHolder == null)
+            return ModifierFunction.cancel(Component.translatable("gtceu.multiblock.turbine.no_rotor"));
 
         EnergyStack EUt = recipe.getOutputEUt();
         long turbineMaxVoltage = turbineMachine.getOverclockVoltage();
         double holderEfficiency = rotorHolder.getTotalEfficiency() / 100.0;
 
-        if (EUt.isEmpty() || turbineMaxVoltage <= EUt.voltage() || holderEfficiency <= 0) return ModifierFunction.NULL;
+        if (EUt.isEmpty() || turbineMaxVoltage <= EUt.voltage() || holderEfficiency <= 0)
+            return ModifierFunction.cancel(Component.translatable("gtceu.multiblock.turbine.no_rotor"));
 
         // get the amount of parallel required to match the desired output voltage
         // Max Parallel is Ceilinged not Floored to ensure the output voltage is actually met,

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/generator/LargeTurbineMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/generator/LargeTurbineMachine.java
@@ -5,6 +5,7 @@ import com.gregtechceu.gtceu.api.blockentity.BlockEntityCreationInfo;
 import com.gregtechceu.gtceu.api.capability.recipe.RecipeCapability;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.machine.feature.ITieredMachine;
+import com.gregtechceu.gtceu.api.machine.multiblock.MultiblockControllerMachine;
 import com.gregtechceu.gtceu.api.machine.multiblock.WorkableElectricMultiblockMachine;
 import com.gregtechceu.gtceu.api.machine.multiblock.part.MultiblockPartMachine;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
@@ -14,11 +15,25 @@ import com.gregtechceu.gtceu.api.recipe.modifier.ModifierFunction;
 import com.gregtechceu.gtceu.api.recipe.modifier.ParallelLogic;
 import com.gregtechceu.gtceu.api.recipe.modifier.RecipeModifier;
 import com.gregtechceu.gtceu.common.machine.multiblock.part.RotorHolderPartMachine;
+import com.gregtechceu.gtceu.utils.FormattingUtil;
 
+import net.minecraft.ChatFormatting;
 import net.minecraft.MethodsReturnNonnullByDefault;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.Style;
 
+import brachy.modularui.api.drawable.Text;
+import brachy.modularui.api.widget.IWidget;
+import brachy.modularui.value.sync.BooleanSyncValue;
+import brachy.modularui.value.sync.IntSyncValue;
+import brachy.modularui.value.sync.LongSyncValue;
+import brachy.modularui.value.sync.PanelSyncManager;
 import lombok.Getter;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -117,38 +132,63 @@ public class LargeTurbineMachine extends WorkableElectricMultiblockMachine imple
     // ******* GUI ********//
     //////////////////////////////////////
 
-    // @Override
-    // public void addDisplayText(List<Component> textList) {
-    // super.addDisplayText(textList);
-    // if (isFormed()) {
-    // var rotorHolder = getRotorHolder();
-    //
-    // if (rotorHolder != null && rotorHolder.getRotorEfficiency() > 0) {Expand commentComment on line L185
-    // textList.add(Component.translatable("gtceu.multiblock.turbine.rotor_speed",
-    // FormattingUtil.formatNumbers(rotorHolder.getRotorSpeed()),
-    // FormattingUtil.formatNumbers(rotorHolder.getMaxRotorHolderSpeed())));
-    // textList.add(Component.translatable("gtceu.multiblock.turbine.efficiency",
-    // rotorHolder.getTotalEfficiency()));
-    //
-    // long maxProduction = getOverclockVoltage();
-    // long currentProduction = getCurrentProduction();
-    //
-    // if (isActive()) {
-    // textList.add(3, Component.translatable("gtceu.multiblock.turbine.energy_per_tick",
-    // FormattingUtil.formatNumbers(currentProduction),
-    // FormattingUtil.formatNumbers(maxProduction)));
-    // }
-    //
-    // int rotorDurability = rotorHolder.getRotorDurabilityPercent();
-    // if (rotorDurability > MIN_DURABILITY_TO_WARN) {
-    // textList.add(Component.translatable("gtceu.multiblock.turbine.rotor_durability", rotorDurability));
-    // } else {
-    // textList.add(Component.translatable("gtceu.multiblock.turbine.rotor_durability", rotorDurability)
-    // .setStyle(Style.EMPTY.withColor(ChatFormatting.RED)));
-    // }
-    // }
-    // }
-    // }
+    public static List<IWidget> additionalDisplay(MultiblockControllerMachine controller,
+                                                  PanelSyncManager syncManager) {
+        if (!(controller instanceof LargeTurbineMachine ltMachine))
+            return Collections.emptyList();
+        if (!controller.isFormed())
+            return Collections.emptyList();
+
+        var rotorHolder = ltMachine.getRotorHolder();
+        if (!(rotorHolder != null && rotorHolder.hasRotor()))
+            return Collections.emptyList();
+
+        BooleanSyncValue isActive = syncManager.getOrCreateSyncHandler("isActive",
+                BooleanSyncValue.class,
+                () -> new BooleanSyncValue(ltMachine::isActive));
+        IntSyncValue rotorSpeed = syncManager.getOrCreateSyncHandler("rotorSpeed",
+                IntSyncValue.class,
+                () -> new IntSyncValue(rotorHolder::getRotorSpeed));
+        IntSyncValue maxRotorSpeed = syncManager.getOrCreateSyncHandler("maxRotorSpeed",
+                IntSyncValue.class,
+                () -> new IntSyncValue(rotorHolder::getMaxRotorHolderSpeed));
+        IntSyncValue totalEfficiency = syncManager.getOrCreateSyncHandler("totalEfficiency",
+                IntSyncValue.class,
+                () -> new IntSyncValue(rotorHolder::getTotalEfficiency));
+        LongSyncValue currentOutput = syncManager.getOrCreateSyncHandler("currentOutput",
+                LongSyncValue.class,
+                () -> new LongSyncValue(ltMachine::getCurrentProduction));
+        LongSyncValue maxOutput = syncManager.getOrCreateSyncHandler("maxOutput",
+                LongSyncValue.class,
+                () -> new LongSyncValue(ltMachine::getOverclockVoltage));
+        IntSyncValue rotorDurability = syncManager.getOrCreateSyncHandler("rotorDurability",
+                IntSyncValue.class,
+                () -> new IntSyncValue(rotorHolder::getRotorDurabilityPercent));
+
+        var rotorSpeedDisplay = Text.dynamic(() -> Component.translatable("gtceu.multiblock.turbine.rotor_speed",
+                FormattingUtil.formatNumbers(rotorSpeed.getIntValue()),
+                FormattingUtil.formatNumbers(maxRotorSpeed.getIntValue())))
+                .asWidget()
+                .setEnabledIf(w -> true);
+        var turbineEfficiencyDisplay = Text.dynamic(() -> Component.translatable("gtceu.multiblock.turbine.efficiency",
+                totalEfficiency.getIntValue()))
+                .asWidget()
+                .setEnabledIf(w -> true);
+        var turbinePowerDisplay = Text.dynamic(() -> Component.translatable("gtceu.multiblock.turbine.energy_per_tick",
+                FormattingUtil.formatNumbers(currentOutput.getIntValue()),
+                FormattingUtil.formatNumbers(maxOutput.getIntValue())))
+                .asWidget()
+                .setEnabledIf(w -> isActive.getBoolValue());
+        var rotorDurabilityDisplay = Text
+                .dynamic(() -> Component.translatable("gtceu.multiblock.turbine.rotor_durability",
+                        rotorDurability.getIntValue())
+                        .setStyle(rotorDurability.getIntValue() > MIN_DURABILITY_TO_WARN ? Style.EMPTY :
+                                Style.EMPTY.withColor(ChatFormatting.RED)))
+                .asWidget()
+                .setEnabledIf(w -> true);
+
+        return Arrays.asList(rotorSpeedDisplay, turbineEfficiencyDisplay, turbinePowerDisplay, rotorDurabilityDisplay);
+    }
 
     //////////////////////////////////////
     // ****** Recipe Logic *******//

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/generator/LargeTurbineMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/generator/LargeTurbineMachine.java
@@ -29,7 +29,6 @@ import brachy.modularui.value.sync.IntSyncValue;
 import brachy.modularui.value.sync.LongSyncValue;
 import brachy.modularui.value.sync.PanelSyncManager;
 import lombok.Getter;
-import net.minecraftforge.client.event.CustomizeGuiOverlayEvent;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
@@ -169,12 +168,12 @@ public class LargeTurbineMachine extends WorkableElectricMultiblockMachine imple
         var rotorSpeedDisplay = Text.dynamic(() -> Component.translatable("gtceu.multiblock.turbine.rotor_speed",
                 FormattingUtil.formatNumbers(rotorSpeed.getIntValue()),
                 FormattingUtil.formatNumbers(maxRotorSpeed.getIntValue()))
-                        .setStyle(Style.EMPTY.withColor(ChatFormatting.WHITE)))
+                .setStyle(Style.EMPTY.withColor(ChatFormatting.WHITE)))
                 .asWidget()
                 .setEnabledIf(w -> true);
         var turbineEfficiencyDisplay = Text.dynamic(() -> Component.translatable("gtceu.multiblock.turbine.efficiency",
                 totalEfficiency.getIntValue())
-                        .setStyle(Style.EMPTY.withColor(ChatFormatting.WHITE)))
+                .setStyle(Style.EMPTY.withColor(ChatFormatting.WHITE)))
                 .asWidget()
                 .setEnabledIf(w -> true);
         var turbinePowerDisplay = Text.dynamic(() -> Component.translatable("gtceu.multiblock.turbine.energy_per_tick",

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/generator/LargeTurbineMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/generator/LargeTurbineMachine.java
@@ -132,6 +132,12 @@ public class LargeTurbineMachine extends WorkableElectricMultiblockMachine imple
     // ******* GUI ********//
     //////////////////////////////////////
 
+
+//    @Override
+//    public List<IWidget> getWidgetsForDisplay(PanelSyncManager syncManager) {
+//        return super.getWidgetsForDisplay(syncManager);
+//    }
+
     public static List<IWidget> additionalDisplay(MultiblockControllerMachine controller,
                                                   PanelSyncManager syncManager) {
         if (!(controller instanceof LargeTurbineMachine ltMachine))
@@ -140,8 +146,13 @@ public class LargeTurbineMachine extends WorkableElectricMultiblockMachine imple
             return Collections.emptyList();
 
         var rotorHolder = ltMachine.getRotorHolder();
-        if (!(rotorHolder != null && rotorHolder.hasRotor()))
-            return Collections.emptyList();
+        if (!(rotorHolder != null && rotorHolder.hasRotor())) {
+            return Collections.singletonList(
+                    Text.dynamic(() -> (Component.translatable("gtceu.multiblock.turbine.no_rotor"))
+                            .setStyle(Style.EMPTY.withColor(ChatFormatting.RED)))
+                            .asWidget()
+                            .setEnabledIf(w -> true));
+        }
 
         BooleanSyncValue isActive = syncManager.getOrCreateSyncHandler("isActive",
                 BooleanSyncValue.class,

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/generator/LargeTurbineMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/generator/LargeTurbineMachine.java
@@ -137,16 +137,16 @@ public class LargeTurbineMachine extends WorkableElectricMultiblockMachine imple
 
         widgets.add(GTMultiblockTextUtil.addEnergyTierLine(this, syncManager));
         widgets.add(GTMultiblockTextUtil.addUnformedWarning(this, syncManager));
-        if (!isFormed())
-            return widgets;
 
+        BooleanSyncValue isFormed = syncManager.getOrCreateSyncHandler("isFormed", BooleanSyncValue.class,
+                () -> new BooleanSyncValue(this::isFormed));
         var rotorHolder = getRotorHolder();
         if (!(rotorHolder != null && rotorHolder.hasRotor())) {
             widgets.add(
                     Text.dynamic(() -> (Component.translatable("gtceu.multiblock.turbine.no_rotor"))
                             .setStyle(Style.EMPTY.withColor(ChatFormatting.RED)))
                             .asWidget()
-                            .setEnabledIf(w -> true));
+                            .setEnabledIf(w -> isFormed.getBoolValue()));
             return widgets;
         }
 
@@ -177,18 +177,18 @@ public class LargeTurbineMachine extends WorkableElectricMultiblockMachine imple
                 FormattingUtil.formatNumbers(maxRotorSpeed.getIntValue()))
                 .setStyle(Style.EMPTY.withColor(ChatFormatting.WHITE)))
                 .asWidget()
-                .setEnabledIf(w -> true);
+                .setEnabledIf(w -> isFormed.getBoolValue());
         var turbineEfficiencyDisplay = Text.dynamic(() -> Component.translatable("gtceu.multiblock.turbine.efficiency",
                 totalEfficiency.getIntValue())
                 .setStyle(Style.EMPTY.withColor(ChatFormatting.WHITE)))
                 .asWidget()
-                .setEnabledIf(w -> true);
+                .setEnabledIf(w -> isFormed.getBoolValue());
         var turbinePowerDisplay = Text.dynamic(() -> Component.translatable("gtceu.multiblock.turbine.energy_per_tick",
                 FormattingUtil.formatNumbers(currentOutput.getIntValue()),
                 FormattingUtil.formatNumbers(maxOutput.getIntValue()))
                 .setStyle(Style.EMPTY.withColor(ChatFormatting.WHITE)))
                 .asWidget()
-                .setEnabledIf(w -> isActive.getBoolValue());
+                .setEnabledIf(w -> isFormed.getBoolValue() && isActive.getBoolValue());
         var rotorDurabilityDisplay = Text
                 .dynamic(() -> Component.translatable("gtceu.multiblock.turbine.rotor_durability",
                         rotorDurability.getIntValue())
@@ -196,7 +196,7 @@ public class LargeTurbineMachine extends WorkableElectricMultiblockMachine imple
                                 Style.EMPTY.withColor(ChatFormatting.WHITE) :
                                 Style.EMPTY.withColor(ChatFormatting.RED)))
                 .asWidget()
-                .setEnabledIf(w -> true);
+                .setEnabledIf(w -> isFormed.getBoolValue());
 
         widgets.add(GTMultiblockTextUtil.addProgressLine(this, syncManager));
         widgets.add(GTMultiblockTextUtil.addWorkingStatusLine(this, syncManager));

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/RotorHolderPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/RotorHolderPartMachine.java
@@ -49,6 +49,7 @@ public class RotorHolderPartMachine extends TieredPartMachine implements IMuiMac
     public static final int SPEED_INCREMENT = 1;
     public static final int SPEED_DECREMENT = 3;
     @SaveField
+    @SyncToClient
     public final NotifiableItemStackHandler inventory;
     @Getter
     public final int maxRotorHolderSpeed;

--- a/src/main/java/com/gregtechceu/gtceu/data/lang/MachineLang.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/lang/MachineLang.java
@@ -891,6 +891,7 @@ public class MachineLang {
         provider.add("gtceu.multiblock.turbine.efficiency", "Turbine Efficiency: %s%%");
         provider.add("gtceu.multiblock.turbine.energy_per_tick", "Energy Output: %s/%s EU/t");
         provider.add("gtceu.multiblock.turbine.energy_per_tick_maxed", "Energy Output: %s EU/t");
+        provider.add("gtceu.multiblock.turbine.no_rotor", "Missing Rotor");
         provider.add("gtceu.multiblock.turbine.obstructed", "Turbine Face Obstructed");
         provider.add("gtceu.multiblock.turbine.efficiency_tooltip",
                 "Each Rotor Holder above %s§7 adds §f10%% efficiency and multiplies EU/t by 2§7.");


### PR DESCRIPTION
## What
Similar to #5334, the Large Turbine UIs were also never updated to MUI2 and so did not display things like their current rotor speed and power output.

## Implementation Details
Needed to add another SyncToClient annotation to RotorHolder. If the RotorHolder's inventory isn't synced, then all attempts to get rotor data fail clientside.

### AI Usage 
- [ X ] No AI driven tools were used for this pull request.

## Outcome
<img width="366" height="334" alt="image" src="https://github.com/user-attachments/assets/052bcf68-0d98-4f44-9124-6469504826ba" />
