### PR TITLE
Fix clashing ore block processing recipes

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagPrefix.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagPrefix.java
@@ -57,6 +57,7 @@ import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
@@ -99,7 +100,7 @@ public class TagPrefix {
 
     public static final TagPrefix NULL_PREFIX = new TagPrefix(GTCEu.id("null"));
 
-    public static final TagPrefix ore = oreTagPrefix(GTCEu.id("stone"), BlockTags.MINEABLE_WITH_PICKAXE)
+    public static final TagPrefix ore = defaultOreTagPrefix(GTCEu.id("stone"), BlockTags.MINEABLE_WITH_PICKAXE)
             .langValue("%s Ore")
             .registerOre(
                     Blocks.STONE::defaultBlockState, () -> GTMaterials.Stone, BlockBehaviour.Properties.of()
@@ -127,7 +128,7 @@ public class TagPrefix {
                             .mapColor(MapColor.DIRT).requiresCorrectToolForDrops().strength(3.0F, 3.0F),
                     ResourceLocation.withDefaultNamespace("block/andesite"));
 
-    public static final TagPrefix oreRedGranite = oreTagPrefix("red_granite", BlockTags.MINEABLE_WITH_PICKAXE)
+    public static final TagPrefix oreRedGranite = oreTagPrefix(GTCEu.id("red_granite"), BlockTags.MINEABLE_WITH_PICKAXE)
             .langValue("Red Granite %s Ore")
             .registerOre(() -> GTBlocks.RED_GRANITE.getDefaultState(), () -> GTMaterials.GraniteRed,
                     BlockBehaviour.Properties.of().mapColor(MapColor.TERRACOTTA_RED).requiresCorrectToolForDrops()
@@ -1091,8 +1092,20 @@ public class TagPrefix {
     }
 
     public static TagPrefix oreTagPrefix(ResourceLocation id, TagKey<Block> miningToolTag) {
-        return new TagPrefix(id)
-                .defaultTagPath("ores/%s")
+        return finalizeOreTagPrefix(new TagPrefix(id).prefixTagPath("ores/%s/%s"), miningToolTag);
+    }
+
+    /**
+     * Internal API, used to allocate "default" ore tag for stone ores. It does not use the prefix tag path to stay
+     * cross-mod compatible
+     */
+    @ApiStatus.Internal
+    public static TagPrefix defaultOreTagPrefix(ResourceLocation id, TagKey<Block> miningToolTag) {
+        return finalizeOreTagPrefix(new TagPrefix(id).defaultTagPath("ores/%s"), miningToolTag);
+    }
+
+    private static TagPrefix finalizeOreTagPrefix(TagPrefix oreTagPrefix, TagKey<Block> miningToolTag) {
+        return oreTagPrefix
                 .prefixOnlyTagPath("ores_in_ground/%s")
                 .unformattedTagPath("ores")
                 .materialIconType(MaterialIconType.ore)

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/OreRecipeHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/OreRecipeHandler.java
@@ -77,7 +77,7 @@ public final class OreRecipeHandler {
             return;
         }
 
-        var inputStack = ChemicalHelper.get(orePrefix, material);
+        var inputTag = ChemicalHelper.getTag(orePrefix, material);
 
         Material byproductMaterial = property.getOreByProduct(0, material);
         ItemStack byproductStack = ChemicalHelper.get(gem, byproductMaterial);
@@ -107,7 +107,7 @@ public final class OreRecipeHandler {
             int crushedCount = property.getOreMultiplier() * oreTypeMultiplier;
             GTRecipeBuilder builder = FORGE_HAMMER_RECIPES
                     .recipeBuilder("hammer_" + prefixString + material.getName() + "_ore_to_crushed_ore")
-                    .inputItems(inputStack)
+                    .inputItems(inputTag)
                     .EUt(16)
                     .duration(10)
                     .category(GTRecipeCategories.ORE_FORGING);
@@ -120,7 +120,7 @@ public final class OreRecipeHandler {
 
             builder = MACERATOR_RECIPES
                     .recipeBuilder("macerate_" + prefixString + material.getName() + "_ore_to_crushed_ore")
-                    .inputItems(inputStack)
+                    .inputItems(inputTag)
                     .outputItems(crushedStack.copyWithCount(crushedCount * 2))
                     .chancedOutput(byproductStack, 1400)
                     .EUt(2)
@@ -141,10 +141,10 @@ public final class OreRecipeHandler {
         if (!ingotStack.isEmpty() && doesMaterialUseNormalFurnace(smeltingMaterial) && !orePrefix.isIgnored(material)) {
             float xp = Math.round(((1 + oreTypeMultiplier * 0.5f) * 0.5f - 0.05f) * 10f) / 10f;
             VanillaRecipeHelper.addSmeltingRecipe(provider,
-                    "smelt_" + prefixString + material.getName() + "_ore_to_ingot", inputStack,
+                    "smelt_" + prefixString + material.getName() + "_ore_to_ingot", inputTag,
                     ingotStack, xp);
             VanillaRecipeHelper.addBlastingRecipe(provider,
-                    "smelt_" + prefixString + material.getName() + "_ore_to_ingot", inputStack,
+                    "smelt_" + prefixString + material.getName() + "_ore_to_ingot", inputTag,
                     ingotStack, xp);
         }
     }

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/built/KJSTagPrefix.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/built/KJSTagPrefix.java
@@ -25,7 +25,7 @@ public class KJSTagPrefix extends TagPrefix {
 
     public static KJSTagPrefix oreTagPrefix(String name) {
         return new KJSTagPrefix(name)
-                .defaultTagPath("ores/%s")
+                .prefixTagPath("ores/%s/%s")
                 .prefixOnlyTagPath("ores_in_ground/%s")
                 .unformattedTagPath("ores")
                 .materialIconType(MaterialIconType.ore)


### PR DESCRIPTION
## What

Fixed all ore blocks registering themselves under the same forge:ores/<material_name> item tag, regardless of the actual stone type of the relevant ore. This resulted in ore recipe generation code in OreRecipeHandler.processOre to possibly emit duplicate recipes under certain circumstances, depending on when item list for each particular tag was computed.

## Implementation Details

Item tag for non-stone ore types changed from forge:ores/<material_name> to forge:ores/<ore_type_name>/<material_name>

Ruby Ore: forge:ores/ruby
Deepslate Ruby Ore: forge:ores/deepslate/ruby
Blackstone Ruby Ore: forge:ores/blackstone/ruby

### AI Usage 

- [ ] No AI driven tools were used for this pull request.
- [X] Yes AI driven tools were used for this pull request.

Claude Sonnet 5 for code review.

## Outcome

There is no clashing of processing recipes for different ore types.

## How Was This Tested

EMI does not show ore types other than stone under ores/ruby tag anymore, verified that other ore types have correct tags assigned to them.

## Potential Compatibility Issues

Item tags for non-stone ore blocks have changed, which might break explicit usages of said tags in addons or packs.
