### PR TITLE
Fix Round Robin Hallucinating Empty Itemstacks

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/pipelike/item/ItemNetHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/pipelike/item/ItemNetHandler.java
@@ -249,10 +249,12 @@ public class ItemNetHandler implements IItemHandlerModifiable {
             toInsert.setCount(data.toTransfer);
 
             ItemStack ins = insertIntoTarget(data.routePath, toInsert, simulate, false);
-            ins.setCount(data.toTransfer - ins.getCount());
+            int insCount = data.toTransfer - ins.getCount();
 
-            inserted += ins.getCount();
-            transferTo(data.routePath, simulate, ins);
+            inserted += insCount;
+            if (insCount > 0) {
+                transferTo(data.routePath, simulate, stack.copyWithCount(insCount));
+            }
         }
 
         ItemStack remainder = stack.copy();


### PR DESCRIPTION
## What
I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET I HATE PIPENET

## Implementation Details
tldr; 
If the attempt by insertIntoTarget() resolves to accepting everything and returns a remainder of 0, it would just assume it was empty and break because haha ItemStack.EMPTY always has a count of 0. Partial insertion would sometimes avoid this because of attempt/remain being different, but in the case of most round robin setups, this would break horrendously...

also confused myself explaining this twice over because the naming isn't exactly, say *clear* on what ins is, it's actually whatever the dist rejected

### AI Usage 
- Yeah Codex-5.6-Luna, was just used to verify I didn't introduce yet another logic error.
## Outcome
My vitriol for pipenet has grown, once again. This system has its days numbered in terms of when I want to strangle it.
## How Was This Tested
- Tested in game, checked values with IntelliJ debugger as a conveyor attempted to round robin. a stack of 64 crafting tables evenly distributed across 3 containers in stacks of 22,22,20 (64 total)
## Additional Information
At least it wasn't the render mines this time... And honestly this aint even pipenet itself it was the conveyor but they are heavily intertwined so it gets my disgruntled emotions regardless.

## Potential Compatibility Issues
Incompatible with my emotional wellbeing. But in regards to actual issues, I do not believe there are any as of present.
