### PR TITLE
Swap to COLOR_DEPTH_WRITE to avoid render layering issues

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/GTRenderTypes.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/GTRenderTypes.java
@@ -71,7 +71,7 @@ public class GTRenderTypes extends RenderType {
             RenderType.CompositeState.builder()
                     .setShaderState(RENDERTYPE_CUTOUT_MIPPED_SHADER)
                     .setTextureState(BLOCK_SHEET_MIPPED)
-                    .setWriteMaskState(COLOR_WRITE)
+                    .setWriteMaskState(COLOR_DEPTH_WRITE)
                     .setDepthTestState(LEQUAL_DEPTH_TEST)
                     .setLayeringState(CUSTOM_CHUNK_LAYERING)
                     .setLightmapState(LIGHTMAP)


### PR DESCRIPTION
- no ai
- rendering is stupid
- stops shutter overlays and cover overlays and clouds with shaders and other fun things just showing through opaque facades.

👍 