### PR TITLE
allowC2S on advanced detector cover toggles

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/cover/detector/AdvancedEnergyDetectorCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/detector/AdvancedEnergyDetectorCover.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.common.cover.detector;
 
+import brachy.modularui.value.sync.DoubleSyncValue;
 import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.capability.ICoverable;
 import com.gregtechceu.gtceu.api.capability.IEnergyInfoProvider;
@@ -147,7 +148,8 @@ public class AdvancedEnergyDetectorCover extends EnergyDetectorCover implements 
                                 .overlay(true, GTGuiTextures.OVERLAY_REDSTONE_ON)
                                 .tooltip(false, t -> t.add("cover.advanced_energy_detector.invert.disabled"))
                                 .tooltip(true, t -> t.add("cover.advanced_energy_detector.invert.enabled")))
-                        .child(new ToggleButton().value(new BooleanSyncValue(this::isUsePercent, this::setUsePercent))
+                        .child(new ToggleButton()
+                                .value(new BooleanSyncValue(this::isUsePercent, this::setUsePercent).allowC2S())
                                 .background(true, ThemeAPI.INSTANCE.getTheme(settings.getTheme())
                                         .getToggleButtonTheme().theme().getBackground())
                                 .overlay(false, GTGuiTextures.BUTTON_EU)

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/detector/AdvancedEnergyDetectorCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/detector/AdvancedEnergyDetectorCover.java
@@ -1,6 +1,5 @@
 package com.gregtechceu.gtceu.common.cover.detector;
 
-import brachy.modularui.value.sync.DoubleSyncValue;
 import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.capability.ICoverable;
 import com.gregtechceu.gtceu.api.capability.IEnergyInfoProvider;

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/detector/AdvancedFluidDetectorCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/detector/AdvancedFluidDetectorCover.java
@@ -129,12 +129,14 @@ public class AdvancedFluidDetectorCover extends FluidDetectorCover implements IM
         syncManager.syncValue("maxValue", maxValueSync);
 
         var buttonRow = coverUIRow()
-                .child(new ToggleButton().value(new BooleanSyncValue(this::isInverted, this::setInverted))
+                .child(new ToggleButton()
+                        .value(new BooleanSyncValue(this::isInverted, this::setInverted).allowC2S())
                         .overlay(false, GTGuiTextures.OVERLAY_REDSTONE_OFF)
                         .overlay(true, GTGuiTextures.OVERLAY_REDSTONE_ON)
                         .tooltip(false, t -> t.add("cover.advanced_fluid_detector.invert.disabled"))
                         .tooltip(true, t -> t.add("cover.advanced_fluid_detector.invert.enabled")))
-                .child(new ToggleButton().value(new BooleanSyncValue(this::isLatched, this::setLatched))
+                .child(new ToggleButton()
+                        .value(new BooleanSyncValue(this::isLatched, this::setLatched).allowC2S())
                         .overlay(false, GTGuiTextures.BUTTON_LOCK)
                         .overlay(true, GTGuiTextures.BUTTON_LOCK)
                         .tooltip(false, t -> t.add("cover.advanced_detector.latch.disabled"))

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/detector/AdvancedItemDetectorCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/detector/AdvancedItemDetectorCover.java
@@ -125,12 +125,14 @@ public class AdvancedItemDetectorCover extends ItemDetectorCover implements IMui
         syncManager.syncValue("maxValue", maxValueSync);
 
         var buttonRow = coverUIRow()
-                .child(new ToggleButton().value(new BooleanSyncValue(this::isInverted, this::setInverted))
+                .child(new ToggleButton()
+                        .value(new BooleanSyncValue(this::isInverted, this::setInverted).allowC2S())
                         .overlay(false, GTGuiTextures.OVERLAY_REDSTONE_OFF)
                         .overlay(true, GTGuiTextures.OVERLAY_REDSTONE_ON)
                         .tooltip(false, t -> t.add("cover.advanced_item_detector.invert.disabled"))
                         .tooltip(true, t -> t.add("cover.advanced_item_detector.invert.enabled")))
-                .child(new ToggleButton().value(new BooleanSyncValue(this::isLatched, this::setLatched))
+                .child(new ToggleButton()
+                        .value(new BooleanSyncValue(this::isLatched, this::setLatched).allowC2S())
                         .overlay(false, GTGuiTextures.BUTTON_LOCK)
                         .overlay(true, GTGuiTextures.BUTTON_LOCK)
                         .tooltip(false, t -> t.add("cover.advanced_detector.latch.disabled"))


### PR DESCRIPTION
## What
Advanced Energy, Item, and Fluid Detector Covers were all missing a .allowC2S() on their mode toggle buttons


### AI Usage 
- [ X ] No AI driven tools were used for this pull request.
