### PR TITLE
Port GregTech Modern to Minecraft 26.1.2 NeoForge

### DIFF
--- a/.scratch/port-26.1/issues/01-upstream-121-playbook.md
+++ b/.scratch/port-26.1/issues/01-upstream-121-playbook.md
@@ -1,0 +1,93 @@
+Type: research
+Status: resolved
+Blocked by: none
+
+## Question
+
+上游 1.20.1→1.21 分支之间做了哪些 Forge→NeoForge 迁移？输出一份 26.1 移植可复用的《翻译手册》。
+
+## Notes
+
+- 对比分支：`1.20.1` vs `1.21`（上游 [GregTechCEu/GregTech-Modern](https://github.com/GregTechCEu/GregTech-Modern)；1.21 = MC 1.21.1 + NeoForge 21.1.248）。
+- 必看面：构建脚本与版本目录（注意 1.21 改用 `gradle/libs.versions.toml`）、包名与 import（`forge`→`neoforge`）、事件总线、registry / 注册、网络包、datagen、client 渲染、mixin、Registrate 与 MUI 在 1.21 分支用的版本（结果喂给「26.x 依赖版本钉死」与「MUI 与 Configuration 路线裁决」）。
+- 只做 fact-finding，不做路线决策；发现直接记入本文件的 `## Findings`，不关闭 ticket。
+
+## Findings
+
+调查日期 2026-09-05，对比上游 `1.20.1` vs `1.21`（均处于 ~8.0.0）。先纠正一个前提：两分支都已用 NeoForged **ModDevGradle**（1.20.1 用 `net.neoforged.moddev.legacyforge`），所以迁移是 Forge→NeoForge **API** 迁移，不是构建插件换代。
+
+### 1. 构建与版本目录
+
+| 面 | 1.20.1 | 1.21 |
+|---|---|---|
+| MC / Loader | MC 1.20.1, Forge 47.4.0 | MC 1.21.1, NeoForge 21.1.248, loader `4` |
+| MDG 插件 | `net.neoforged.moddev.legacyforge` 2.0.86 | `net.neoforged.moddev` 2.0.141 |
+| Java | 17 | 21 |
+| Parchment | 2023.09.03 | 2024.11.17 |
+| settings 插件仓库 | `maven.minecraftforge.net` | `maven.neoforged.net` |
+| 版本目录 | `gradle/libs.versions.toml` + `gradle/forge.versions.toml`（**1.21 沿用同名文件，别被名字误导**） | 同上结构 |
+
+- `build.gradle`：1.21 删掉 `obfuscation { createRemappingConfiguration(...) }`（MDG 内置处理）；其余 sourceSets/configurations 结构基本不动。
+- `dependencies.gradle` 前缀变化：`modCompileOnly/modLocalRuntime/modApi/modImplementation` → `compileOnly/localRuntime` + `jarJar(api(...))`；mixin 显式依赖（mixin 0.8.7、mixinExtras 0.5.0-rc.3、annotationProcessor）在 1.21 整段删除（NeoForge/MDG 自带）。
+- `moddevgradle.gradle`：`legacyForge { version = minecraftForge }` → `neoForge { version = neoForge }`；`forge.enabledGameTestNamespaces` → `neoforge.enabledGameTestNamespaces`；`forge.logging.markers` 字面保留；1.21 新增 `validateAccessTransformers`、gameTestClient run、sodium shell-lib strip 任务。
+- `resources.gradle` + `src/main/templates/META-INF/*.toml`：`loaderVersion [forge_major,)` → `[loader(4),)`，依赖 `mandatory=true/false` → `type="required"/"optional"`，`modId="forge"` → `modId="neoforge"` + `minecraft_version "[1.21, 1.21.1]"`；1.21 新增 `enumExtensions`、modernfix integration entrypoint、按 mod 条件加载的 `[[mixins]]` 块、sodium/embeddium/sable 可选依赖。
+
+### 2. 包名/Import 翻译表
+
+| 1.20.1 (Forge) | 1.21 (NeoForge) |
+|---|---|
+| `net.minecraftforge.eventbus.api.*` | `net.neoforged.bus.api.*` |
+| `net.minecraftforge.fml.*`（Mod/ModList/FMLEnvironment/FMLLoader/ModLoader/lifecycle） | `net.neoforged.fml.*`（同名） |
+| `net.minecraftforge.event.*`（AddPackFindersEvent 等） | `net.neoforged.neoforge.event.*` |
+| `net.minecraftforge.common.capabilities.*` | `net.neoforged.neoforge.capabilities.*` |
+| `net.minecraftforge.network.*` SimpleChannel | `net.neoforged.neoforge.network.*` payload 系统 |
+| `net.minecraftforge.fluids.FluidStack` / energy / items | `net.neoforged.neoforge.fluids / energy / items` |
+| `net.minecraftforge.client.event.*` | `net.neoforged.neoforge.client.event.*`（多为同名类） |
+| `net.minecraftforge.server.ServerLifecycleHooks` | `net.neoforged.neoforge.server.ServerLifecycleHooks` |
+| `net.minecraftforge.registries.*` | `net.neoforged.neoforge.registries.*`（RegisterEvent/NewRegistryEvent/DataPackRegistryEvent 同名） |
+| `ResourceLocation.parse` | `tryParse` / `fromNamespaceAndPath` / `read` |
+
+### 3. 入口与事件总线
+
+- `FMLJavaModLoadingContext.get().getModEventBus()` → 构造器注入 `GTCEu(IEventBus modBus, FMLModContainer container)`，`GTCEu.gtModBus` 静态持有；`DistExecutor.unsafeRunForDist(ClientProxy::new, CommonProxy::new)` 删除，改为 `CommonProxy.init(modBus)` 直接调用 + `modBus.addListener(GTNetwork::registerPayloads)`；`@EventBusSubscriber(modid=...)` 保留（包换 Neo）。
+- `FMLConstructModEvent` 延迟 init 模式取消；`isDataGen()` 由 `FMLLoader.getLaunchHandler().isData()` → `DatagenModLoader.isRunningDataGen()`。
+
+### 4. 注册表
+
+- 自定义 GT 注册表改用 `RegistryBuilder<>(key).sync(...).create()` + `NewRegistryEvent`（`GTRegistries.init(modBus)`，HIGHEST 解冻 / LOW 批量注册，`IdMappingEvent` 跟踪冻结）。
+- 矿脉/基岩矿/基岩流体改为 **datapack registry**（`DataPackRegistryEvent.NewRegistry`），对应 7.0.0 breaking change「образи veins 必须 datagen」；旧版 vein 同步包 `SPacketSync{Ore,Fluid,BedrockOre}Veins` 删除。
+- 材料流：`MaterialEvent`（ModLoader.postEvent）→ `RegisterEvent(Keys.MATERIAL)` + `PostMaterialEvent`（`ModLoader.postEventWrapContainerInModOrder`）。
+- 香草注册表一律 `DeferredRegister.register(modBus)`（1.21 新增 `ATTACHMENT_TYPES`、`DATA_COMPONENTS`、`ITEM/FLUID_INGREDIENT_TYPES` 直挂 modBus；`GTGlobalLootModifiers` 入口消失，见下条 datagen）。
+
+### 5. 网络
+
+`SimpleChannel + INetPacket(FriendlyByteBuf encode/decode) + NetworkDirection + PacketDistributor` → `CustomPacketPayload（TYPE + StreamCodec CODEC + execute） + RegisterPayloadHandlersEvent（playToClient/playToServer/playBidirectional） + PacketDistributor.sendTo*`。发送端语义基本一一对应。
+
+### 6. 能力/配方成分/物品数据
+
+- Capability：Forge `CapabilityToken/RegisterCapabilitiesEvent` + `GTCapability.register` 集中式 → NeoForge `Capabilities.*` 逐 block/item `event.register*`（`RegisterCapabilitiesEvent` 同名异包）。
+- NBT 成分 → Data Component：`StrictNBT/PartialNBT/NBTPredicateIngredient + CraftingHelper.register` → `DataComponentIngredient`、`Sized/Compound/Intersection/DataComponent` Fluid/Item Ingredient；datagen 新增 `ProviderType.DATA_MAP + DataMapsHandler`。
+- `ProviderType.register` → `registerProvider`（Registrate API 改名）。
+
+### 7. Client 渲染与 Mixin
+
+- Mixin：`compatibilityLevel JAVA_17→JAVA_21`，mixinextras 显式依赖删除；client mixins 大换血——删 REI/Xaero/FTBChunks/Oculus/Embeddium 兼容及 `forge.*` accessor、`CapabilityDispatcher*`、`LootDataManagerMixin`；bloom 重写面向 **Sodium 0.8 NeoForge**（新增 `SectionCompiler/LightPipelineAware/BufferBuilderAccessor` 等，Embeddium→Sodium，附 forgified-Fabric-API 渲染依赖 + sodium shell-lib strip 任务）。
+- Client 事件类多为同名换包（RegisterKeyMappings/RegisterGuiLayers/RegisterParticleProviders/EntityRenderersEvent/ModelEvent/RegisterItemDecorations/RegisterClientExtensions + `IClientFluidTypeExtensions`）。
+
+### 8. 关键第三方版本（喂「依赖钉死」与「MUI/Configuration 裁决」）
+
+| 库 | 1.20.1 | 1.21 |
+|---|---|---|
+| Registrate | `MC1.20-1.3.11` | `MC1.21-1.3.0+67` |
+| Configuration | `3.1.0-forge`（`configuration-1.20.1`） | `3.1.1-neoforge`（`configuration-1.21.1`） |
+| MUI | `3.3.1-SNAPSHOT`（`modularui-mc1.20.1`） | `3.3.1-SNAPSHOT`（`modularui-mc1.21.1`，坐标仅换 MC 后缀） |
+| KJS/Rhino | 2001.6.5 / 2001.2.3（+architectury） | 2101.7.2 / 2101.2.7（architectury 依赖消失） |
+| JEI / AE2 / Create / Curios | 15.20 / 15.0.18 / 6.0.6 / curios-forge 5.9.1 | 19.25 / 19.2.8 / 6.0.10 / curios-neoforge 9.4.2 |
+| REI | 有（rei bundle） | **删除**（mods.toml 仅残留 rei 条件 mixin） |
+| GameStages | 正常版本 | 无 1.21 版，用 Forge-1.20.3 占位（`TODO` 注释） |
+
+26.1 移植启示：机械性替换（包名/总线/网络/DeferredRegister 挂载）可脚本化；真正的语义坑是 datapack 化矿脉、Data Component 化、Sodium 渲染重写三处。
+
+## Answer
+
+翻译手册已完成并记录在本票的 `## Findings`：上游 1.21 分支是 Forge→NeoForge API 迁移的参照，不是 26.x 基线；构建、事件总线、注册表、网络、数据组件、渲染和 mixin 的迁移边界均已列出。上游无 26.x 分支，因此最终实现仍从当前 1.20.1 基线移植，并把上游 1.21 作为迁移参考。

--- a/.scratch/port-26.1/issues/02-dep-pinning.md
+++ b/.scratch/port-26.1/issues/02-dep-pinning.md
@@ -1,0 +1,91 @@
+Type: research
+Status: resolved
+Blocked by: none
+
+## Question
+
+`dependencies.gradle` + `gradle/forge.versions.toml` 里的每一项，其 26.1.2 / NeoForge 26.x 坐标是什么（含 Maven 仓库 URL）？确认不了的标"砍"并移交「砍件清单与代码牵连面」。
+
+## Notes
+
+- **第一步先查上游 1.21 分支的 MUI 与 Configuration 版本**（Q9 决议），再定 26.x 路线。
+- 第一遍普查结论（2026-09-05，供复核而非复用）：有——Registrate 26.1-1.5.0、JEI 29.35.0.94、Jade 26.1.10、Curios 15.0.0+26.1.2、AE2 26.1.11-beta、KubeJS 8.0.4 + Rhino + Architectury 20.0.12、FTB 全家桶 26.1.2.x、CC:T v26.1.2-1.120.0、Xaero Minimap 26.4.2 / WorldMap 1.45.0、Cloth Config v26.1.154、MixinExtras 0.5.5（NeoForge 自带）；无——EMI、官方 Create、Embeddium（含 Oculus 待查）、GameStages（替代品 Chapters 2.0 待评估）、MUI、Configuration。
+- NeoForge 取 26.1.2.x 最新 stable（自称 .100 的以 Maven 为准）。
+- 用户确认：目标保持 MC 26.1.2 / NeoForge 26.1.2.x；曾考虑从 26.1-1.5.0 tag 源码构建 Registrate，后续研究确认该 tag 已有可消费二进制，最终决议以 `maven.gegy.dev` 二进制为准。
+- 只做 fact-finding；发现记入 `## Findings`，不关闭 ticket。
+
+## Findings（2026-09-05 复核，Modrinth API + CurseForge + maven.neoforged.net 实测）
+
+**上游 1.21 分支结论（Q9 第一步）：** `gradle/libs.versions.toml` 在 1.21 分支只剩 MC/NF/toolchain，依赖已搬到 `gradle/forge.versions.toml`：Configuration = `3.1.1-neoforge`（`dev.toma.configuration:configuration-1.21.1`），MUI = `3.3.1-SNAPSHOT`（`brachy.modularui:modularui-mc1.21.1`）。附带：上游已删 Oculus/REI/AE2WTLib/Cloth，GameStages 注释掉（留 1.20.3 占位坐标），渲染改 Sodium+Iris+Embeddium 路线。
+
+| 依赖 | 26.x 版本 | Maven URL | 状态 |
+|---|---|---|---|
+| NeoForge | 26.1.2.99（stable，mvnrepository 2026-08-26；官方索引 stable 至少到 .95，实施时重解） | https://maven.neoforged.net/releases/ | ok |
+| Registrate | 26.1-1.5.0 | https://maven.tterrag.com/ | ok（沿用普查，实施时重验） |
+| Configuration | **4.1.2+26.1.2**（新坐标 `dev.toma.configuration:configuration-neoforge`；旧 `configuration-26.1` 写法已废弃） | https://repo.repsy.io/mvn/toma/public/（备 https://api.repsy.io/mvn/toma/public） | ok**普查误判纠正：26.1.2 版存在** |
+| MUI | 无 26.x（CurseForge 仅到 1.20.1；无 mc26 artifact） | — | **cut**→砍件清单 |
+| MixinExtras | 0.5.5（NeoForge 自带） | 随 NF | ok（沿用） |
+| JEI | 29.35.0.94（Modrinth 2026-09-03，beta） | https://maven.blamejared.com/（镜像 https://modmaven.dev） | ok |
+| REI | 26.1.819+neoforge（2026-06-18，beta；普查未提，上游虽删但 artifact 存在） | https://api.modrinth.com/maven（+ https://maven.shedaniel.me/） | ok |
+| EMI（官方） | 止于 1.21.1；仅非官方 port（emi-unofficial-port-unstable，Beta，`curse.maven:emi-unofficial-port-unstable-1544558`） | — | **cut**→砍件清单（要官方就砍） |
+| Jade | 26.1.10+neoforge（2026-08-15，release） | https://api.modrinth.com/maven | ok |
+| Curios | 15.0.0+26.1.2 | https://maven.theillusivec4.top/ | ok（沿用，实施时重验） |
+| AE2 | 26.1.11-beta（2026-08-25；AE2WTLib 走 cursemaven 沿用） | https://api.modrinth.com/maven | ok |
+| Create/Ponder/Flywheel（官方） | 止于 Create 6.0.10/1.21.1（2026-04-21），无 26.x | https://maven.createmod.net（查无 26.x） | **cut**→砍件清单（牵连 Create compat + Ponder 联动） |
+| KubeJS | 26.1.2-8.0.4+neoforge（2026-07-23，beta；依赖 Architectury 必需） | https://maven.latvian.dev/releases（Architectury https://maven.shedaniel.me/） | ok；Rhino/Arch 20.0.12 沿用待重验 |
+| FTB 全家桶 | 26.1.2.x | https://maven.ftb.dev/releases | ok（沿用，实施时重验） |
+| CC:T | v26.1.2-1.120.0（2026-06-15，alpha） | https://maven.squiddev.cc | ok |
+| Cloth Config | 26.1.154+neoforge（release） | https://maven.shedaniel.me/ | ok |
+| Xaero | Minimap 26.4.2 / WorldMap 1.45.0 | https://chocolateminecraft.com/maven/ | ok（沿用，实施时重验） |
+| Embeddium/Oculus | Modrinth 无 26.1.2 版；上游 1.21 已弃 Oculus 转 Sodium+Iris | — | **cut**→砍件清单（备选 Sodium+Iris 直引路线待评估） |
+| ModernFix | 5.27.22+mc26.1.2（2026-08-31，release） | https://api.modrinth.com/maven | ok |
+| GameStages | 止于 1.20.x；替代品 Chapters 2.0（`curse.maven:chapters-1538047:8560538`，26.1.2，2026-08-02，KubeJS/FTB 联动已适配） | https://cursemaven.com | **cut**（GameStages 本体）→砍件清单；Chapters 待评估 |
+| 纯 dev 运行时（Spark/Observable/JAVD/Trenzalore/JourneyMap/KFF/Bookshelf/RLib/Argonauts/Heracles/WorldStripper） | cursemaven fileId 沿用，实施时逐个重解 | https://cursemaven.com | carry |
+
+砍件移交：EMI（官方）、Create 官方（含 Ponder/Flywheel 联动）、Embeddium/Oculus、GameStages 本体。MUI 已移交「MUI 与 Configuration 路线裁决」并改为完整移植；Configuration 从缺失名单移除。
+
+## Findings
+
+### Remaining verification
+
+核验日期：2026-09-05。下表只记已从上游仓库、Maven、Modrinth 或 CurseForge 元数据核验的事实；`curse.maven` 坐标最后一段是 CurseForge **file ID**，不是版本号。
+
+| 依赖 | 26.1.2 坐标/文件（仓库） | Loader / 状态 |
+|---|---|---|
+| Registrate | `com.tterrag.registrate:Registrate:MC26.1-1.5.0` (`https://maven.gegy.dev/releases/`) | NeoForge library / verified |
+| ModularUI | 无 artifact；最近源码为 `1.21.1` branch | no 26.1.2 artifact / unresolved port; project port required |
+| Configuration | `dev.toma.configuration:configuration-neoforge:4.1.2+26.1.2` (`https://repo.repsy.io/mvn/toma/public/`；backup `https://api.repsy.io/mvn/toma/public/`) | NeoForge / verified |
+| AE2WTLib | Modrinth `ncEqrp7o`, `ae2wtlib-26.1.1-beta.jar` | NeoForge, MC 26.1.2 / verified; no target CurseMaven file confirmed |
+| Rhino | `dev.latvian.mods:rhino:2101.2.8-build.91` (`https://maven.latvian.dev/releases`)；CF file `8463898` | NeoForge-compatible / verified |
+| Architectury | `dev.architectury:architectury-neoforge:20.0.12` (`https://maven.shedaniel.me/`；Modrinth file `qb6YlbgG`) | NeoForge / verified |
+| FTB Library | `dev.ftb.mods:ftb-library-neoforge:26.1.2.7` (`https://maven.ftb.dev/releases/`) | NeoForge / verified |
+| FTB Teams | `dev.ftb.mods:ftb-teams-neoforge:26.1.2.4` | NeoForge / verified |
+| FTB Quests | `dev.ftb.mods:ftb-quests-neoforge:26.1.2.7` | NeoForge / verified |
+| FTB Chunks | `dev.ftb.mods:ftb-chunks-neoforge:26.1.2.8` | NeoForge / verified |
+| KotlinForForge | `thedarkcolour:kotlinforforge-neoforge:6.3.0` (`https://thedarkcolour.github.io/KotlinForForge/`)，Modrinth file `yi2Fz7Hg` | NeoForge, `kotlinforforge-6.3.0-all.jar` / verified |
+| Spark | `curse.maven:spark-361579:8275631` | NeoForge `spark-1.10.173-neoforge.jar` / verified |
+| Observable | no 26.1.2 file; latest checked NeoForge is 1.21.1 file `6697124` | not-found/cut |
+| JAVD | `curse.maven:javd-370890:7869081` | NeoForge `javd-neo-26.1.1.0+mc26.1.1.jar`, CF lists 26.1.2 / verified |
+| Trenzalore | `curse.maven:trenzalore-870210:7957903` | NeoForge `trenzalore-neo-26.1.2.1+mc26.1.2.jar` / verified |
+| JourneyMap API | `info.journeymap:journeymap-api-neoforge:2.0.0-26.1-SNAPSHOT` (`https://jm.gserv.me/repository/maven-public/`) | NeoForge snapshot / verified for 26.1 line; exact 26.1.2 release unresolved |
+| JourneyMap Forge | `curse.maven:journeymap-32274:8768945` | NeoForge `journeymap-neoforge-26.1.2-6.0.7.jar` / verified |
+| ResourcefulLib | `com.teamresourceful.resourcefullib:resourcefullib-neoforge-26.1:4.0.1` (`https://maven.teamresourceful.com/repository/maven-public/`)；CF file `7927296` | NeoForge / verified |
+| Argonauts | no 26.1.2 file in the Argonauts/Odyssey Allies project | not-found/cut |
+| Heracles | no 26.1.2 file in the Heracles/Odyssey Quests project | not-found/cut |
+| WorldStripper | no 26.1.2 CurseForge file | not-found/cut |
+| GameStages | no 26.1.2 official file | not-found/cut |
+| Bookshelf | `curse.maven:bookshelf-228525:8551659`, `Bookshelf-neoforge-MC26.1.2-26.1.2.15.jar` | NeoForge / verified |
+
+Registrate 的 `26.1-1.5.0` tag 精确指向 commit `d5a1d33c87325b41482dda6981f4543e79269e3e`。事实是：`maven.gegy.dev/releases` 已发布该版本的 JAR、sources JAR 和 POM；同路径的 `maven.tterrag.com` 核验为 404。上游 README 的形状是加入 `maven.gegy.dev/releases`，消费 `com.tterrag.registrate:Registrate:MC26.1-1.5.0`。研究性建议（不是本 ticket 的决策）：按该 tag 源码构建后执行 `publishToMavenLocal`，项目用 `mavenLocal()` 消费同一坐标；这比 vendor source 更符合上游的 `maven-publish` 设置。Composite build 可行但未见上游文档支持。
+
+ModularUI 的 Modrinth 项目只列到 1.20.1，26.1.2 artifact 未找到；官方现代源码是 `https://github.com/brachy84/ModularUI-Modern` 的 `1.21.1` branch（commit `c13e141b830c70922c3540ea245ecf5d29e1029d`），不是 v3.3.1 tag（该 tag 指向 1.20.1）。该 branch 的构建前提是 Java 21、Gradle 8.14、NeoForge 21.1.215、ModDevGradle 2.0.86 和 Parchment 2024.11.17；其 `gradle.properties` 的 Maven group 是 `brachy.modularui`。
+
+来源：Registrate `https://github.com/tterrag1098/Registrate`；Configuration `https://github.com/Toma1O6/Configuration`；AE2WTLib `https://github.com/Mari023/AE2WirelessTerminalLibrary`；Rhino `https://github.com/kube-mods/rhino`；Architectury `https://github.com/architectury/architectury-api`；FTB `https://github.com/FTBTeam/FTB-Library`、`https://github.com/FTBTeam/FTB-Teams`、`https://github.com/FTBTeam/FTB-Quests`、`https://github.com/FTBTeam/FTB-Chunks`；KFF `https://github.com/thedarkcolour/KotlinForForge`；Spark `https://github.com/lucko/spark`；Observable `https://github.com/tasgon/observable`；JAVD `https://github.com/UnRealModding/JAVD`；ResourcefulLib `https://github.com/Team-Resourceful/ResourcefulLib`；Bookshelf `https://github.com/Darkhax-Minecraft/Bookshelf`。JourneyMap source is unavailable; use `https://github.com/TeamJM/journeymap` issue tracker. Trenzalore `https://www.curseforge.com/minecraft/mc-mods/trenzalore`、WorldStripper `https://www.curseforge.com/minecraft/mc-mods/world-stripper`、Argonauts `https://www.curseforge.com/minecraft/mc-mods/odyssey-allies`、Heracles `https://www.curseforge.com/minecraft/mc-mods/odyssey-quests` have only CurseForge project pages in the checked metadata; no public source URL was surfaced.
+
+当前 `forge.versions.toml` 的旧值仍是**未经核验的 carry-over**，不是目标 pin：Spark `4738952`、Observable `5643037`、JAVD `4803995`、Trenzalore `4848244`、JourneyMap API `1.20-1.9-SNAPSHOT`、JourneyMap `5789363`、ResourcefulLib `5659871`、Argonauts `5263580`、Heracles `5406935`、AE2WTLib `5217955`、GameStages `15.0.2`、Bookshelf `20.2.13`。尤其 `5263580`、`5406935`、`5217955` 等是旧 Minecraft/loader 文件，不能据其推导 26.1.2 支持。
+
+## Answer
+
+依赖策略已经决议：目标保持 MC 26.1.2 + NeoForge 26.1.2.x；可核验的 26.1.2 版本进入 pin 表，不可核验的依赖暂时砍掉。Registrate 使用 `com.tterrag.registrate:Registrate:MC26.1-1.5.0`（`https://maven.gegy.dev/releases/`），不使用 26.2 专用的 `26.2-1.6.0`。Configuration 使用 `dev.toma.configuration:configuration-neoforge:4.1.2+26.1.2`。JourneyMap 保留，使用 CurseForge file `8768945`（`journeymap-neoforge-26.1.2-6.0.7.jar`）；对应 API 仍按 26.1 snapshot 处理并在构建阶段验证。
+
+MUI 没有 26.1.2 构件，转入「MUI 与 Configuration 路线裁决」：完整移植 `ModularUI-Modern` 的 `1.21.1` 分支到本项目，保留独立模块边界；这不是本票的实现交付。

--- a/.scratch/port-26.1/issues/03-mui-config-decision.md
+++ b/.scratch/port-26.1/issues/03-mui-config-decision.md
@@ -1,0 +1,21 @@
+Type: grilling
+Status: resolved
+Blocked by: 02
+
+## Question
+
+基于「26.x 依赖版本钉死」的查证结果，MUI 与 Configuration 二者各走升级 / 自移植 / 替换 / 等中的哪条路线？
+
+## Notes
+
+- HITL：必须与人类 live 对话决议，agent 不许替人类作答。调用 grilling + domain-modeling 两个 skill。
+- 输入：02 的 `## Findings`（尤其上游 1.21 分支用的版本）。
+- 输出：决议 comment + 关闭 ticket，并在 map 的 Decisions so far 记一行 gist（指回本 ticket）。
+- 若决议引入新术语（如替代库名），同步更新根 `CONTEXT.md`。
+
+## Answer
+
+- **MUI**：完整移植 `ModularUI-Modern` 的 `1.21.1` 分支到本项目的 26.1.2 / NeoForge 目标。保留 MUI 的独立模块边界与完整 API，不缩减为 GTM 当前引用的最小子集。移植产物暂放在本仓库内，后续 GTM 通过项目内模块依赖消费。
+- **Configuration**：不自行重写，使用已核验的 `dev.toma.configuration:configuration-neoforge:4.1.2+26.1.2`，仓库为 `https://repo.repsy.io/mvn/toma/public/`（必要时使用 `https://api.repsy.io/mvn/toma/public/`）。
+- **Registrate**：不并入本票的自移植范围，使用已核验的 `com.tterrag.registrate:Registrate:MC26.1-1.5.0`；26.2 专用的 `26.2-1.6.0` 不使用。
+- **验收边界**：MUI 移植必须先能独立编译，再能被 GTM 编译 classpath 消费；Configuration 依赖必须能解析并通过 GTM 的配置初始化。具体实现任务进入最终移植 spec，不在本决策票执行。

--- a/.scratch/port-26.1/issues/04-cut-list-scope.md
+++ b/.scratch/port-26.1/issues/04-cut-list-scope.md
@@ -1,0 +1,25 @@
+Type: task
+Status: resolved
+Blocked by: 02
+
+## Question
+
+被砍依赖各自牵连哪些代码？给出 spec 级的删除 / 桩化范围。
+
+## Notes
+
+- 候选砍件（以 02/03 结论为准）：EMI（runtime 二选一，已有 JEI 可留）、Create + Ponder 联动、Embeddium / Oculus（client runtime）、GameStages（→ Chapters 2.0 或删）、Observable / Argonauts / Heracles / WorldStripper 等无 26.1.2 构件的 dev-only runtime。MUI 不属于砍件，进入完整移植范围。
+- 工作：在本仓库 grep 每个砍件的引用点并计数，按模块汇总牵连面；spec 写清删哪些文件、桩哪些接口。只产出决策与范围，不动手删代码。
+- 完成后决议 comment + 关闭 ticket，map 记一行。
+
+## Answer
+
+本票按当前依赖研究结果闭合。以下依赖不进入 26.1.2 主线的运行时或构建依赖：官方 EMI、Create/Ponder/Flywheel、Embeddium/Oculus、GameStages、Observable、Argonauts、Heracles、WorldStripper。Chapters 不作为 GameStages 的自动替代品纳入本 spec。
+
+- 删除对应的 Gradle 依赖、版本目录、运行配置和 mod metadata 声明。
+- 删除或隔离对应的 GTM integration 模块：Create display/compat、Embeddium compat、EMI recipe-viewer integration、GameStages hooks，以及只服务于被砍 dev runtime 的启动配置。
+- 不为被砍依赖保留空壳 API 或假实现；GTM 核心行为必须在没有这些 mod 时继续编译和运行。
+- JEI、REI、Jade、AE2、AE2WTLib、KubeJS、FTB、CC:T、Xaero、JourneyMap、Curios 等已核验或明确保留的集成不在砍件范围。
+- MUI 不是砍件，按「MUI 与 Configuration 路线裁决」完整移植。
+
+本答案是基于已确认依赖政策的 spec 范围决议；实现阶段仍须用 26.1.2 解析结果复核每个可选构件的真实 file ID。

--- a/.scratch/port-26.1/issues/05-api-gap-inventory.md
+++ b/.scratch/port-26.1/issues/05-api-gap-inventory.md
@@ -1,0 +1,32 @@
+Type: research
+Status: resolved
+Blocked by: none
+
+## Question
+
+MC 1.20.1→26.1.2 与 Forge→NeoForge 的 API 差异中，GTM 体量（1725 个 java 文件）会撞上哪些？输出差异清单。
+
+## Notes
+
+- 必查面：Mojang mappings 与方法签名变更、registry / 注册与 datagen、事件总线、网络（networking）、client 渲染管线、mixin 目标方法、配置文件库。
+- 可与「上游 1.21 翻译手册」并行先行：重点放在 1.21→26.x 的增量差异 + Mojang 大版本变更，不要重复造 01 的 Forge→NeoForge 部分，01 完成后做一次对齐。
+- 只做 fact-finding；发现记入 `## Findings`，不关闭 ticket。
+
+## Findings
+
+> 范围：1.21→26.x 增量 + Mojang 大版本变更；Forge→NeoForge 基础翻译见 01 票，本票不重复。来源：NeoForge 26.1 primer / 1.21.x primers / 21.x release notes / NeoForge docs（networking、registries、transfer rework）。
+
+- [ ] 工具链/mappings（blocks-build）：Java 21→25（Gradle ≥9.1，MDG ≥2.0.141，IDE 2025.2+/2025-12），删除 Parchment（26.1 已反混淆，用 Mojang 官方参数名）；`Block/Item.Properties` 必须显式设 id（用 `DeferredRegister.Blocks/Items.register*` 自动处理）；`Level#random` 改 protected→`getRandom()`（mechanical-rename，全仓量大）。
+- [ ] 注册表/数据驱动（blocks-build 为主）：`DeferredRegister` + `RegistryBuilder.sync(true)` 仍在；`RegistryAccess.registry→lookup`、`Registry.getHolder→get` 改名（mechanical-rename）；`Holder/HolderSet` 普及（`HolderSet.direct`、`wrapAsHolder`、`getOrThrow`），tag 目录去复数（`tags/blocks→tags/block` 等，mechanical-rename）；附魔已是 datapack registry（`Holder<Enchantment>`，behavior-change，GTM 附魔相关配方/Tooltip 必改）。
+- [ ] Datagen（blocks-build）：`GatherDataEvent` 在 1.21.4+ 拆分为 Client/Server（`clientData`/`serverData` run），`RecipeProvider`/`DatapackBuiltinEntriesProvider + RegistrySetBuilder` 用法变，`event.createProvider/createDatapackRegistryObjects` 新 API；26.1 战利品系统 unrolling（`LootPoolEntryType/FunctionType/ConditionType…` 删除→直接注册 `MapCodec`，`getType→codec`，`CODEC→MAP_CODEC`）+ `Validatable/ValidationContext` 校验重构（behavior-change，GTM 战利品/矿脉战利品表受影响）；村民交易 datapack 化（GTM 基本无感）。
+- [ ] DataMap（behavior-change）：`COMPOSTABLES`、`VIBRATION_FREQUENCY` 等静态 map 改 DataMap（`DataMapType/AdvancedDataMapType + DataMapProvider`），Holder 查询；GTM 材料/方块附加属性若用静态 map 需迁移。
+- [ ] 事件总线（mechanical-rename + 部分 blocks-build）：`Event.Result` 删除、TickEvent 重构（见 01 票增量）；新增 `RegisterPayloadHandlersEvent` / `RegisterClientPayloadHandlersEvent`（网络）、`RegisterCapabilitiesEvent` key 变更、`ExtractLevelRenderStateEvent`（渲染）；`RenderHighlightEvent` 删除→`ExtractBlockOutlineRenderStateEvent + CustomBlockOutlineRenderer`。
+- [ ] 网络（blocks-build，重写面最大）：Forge `SimpleChannel/EventChannel + FriendlyByteBuf.Reader` 删除→`CustomPacketPayload + Type<T> + StreamCodec + PayloadRegistrar`（`playBidirectional/playToClient/playToServer`，`executesOn(HandlerThread)`），发送经 `PacketDistributor` / `ClientPacketDistributor.sendToServer`，上限 32KiB（C→S）/1MiB（S→C），`versioned/optional` 协商；1.21.6 起 client handler 必须经 `RegisterClientPayloadHandlersEvent` 注册（`DirectionalPayloadHandler` 删除）。GTM 大量机器 GUI 同步包需逐个重写 codec。
+- [ ] 传输/Capability（behavior-change，工作量最大）：21.9.1 transfer rework：`IItemHandler/IFluidHandler/IEnergyStorage`→`ResourceHandler<T> + EnergyHandler + SnapshotJournal` 事务模型 + `ItemAccess` 上下文，`Capabilities.ItemHandler.*→Capabilities.Item.*`，旧接口 deprecated 但可用适配器（`IItemHandler.of` 等）分阶段迁移。GTM 机器仓/管道/线缆/ covers 全撞上。
+- [ ] 客户端渲染（behavior-change，重写面第二）：1.21.2 实体 `EntityRenderState`（`EntityRenderer<T,S>` + `createRenderState/extractRenderState`，`RenderLayer<T,S>`）；1.21.4 物品模型 datagen 化（`BlockEntityWithoutLevelRenderer` 删除→`SpecialModelRenderer`，`ItemModelResolver/ItemStackRenderState`）；1.21.6 GUI 两阶段（`GuiGraphics` 持 `GuiRenderState`，`submit*`，tooltip `set*ForNextFrame`，颜色须 ARGB 不透明，`RenderPipeline` 排序）；1.21.9+ 世界渲染两阶段（`BlockEntityRenderer<T,S>` 三方法 + `SubmitNodeCollector`，`RenderLevelStageEvent` 需经 `LevelRenderState(BaseRenderState)` 挂数据，粒子 `FeatureRenderDispatcher`）。GTM 大量 Screen/BER/动态高亮需重测；shader JSON 与盔甲 `ArmorMaterial→ToolMaterial/Equippable/EquipmentModel` 改动连带。
+- [ ] Mixin 目标（blocks-build + 脆弱）：高频目标签名变：`BlockBehaviour#onRemove`→`preRemoveSideEffects + affectNeighborsAfterRemoval`，`Item#getEnchantmentValue/isValidRepairItem` 删除（→data component），`Tier→ToolMaterial`，`EntityEquipment` 重构，模型烘焙 `getDependencies/resolveParents→resolveDependencies`；另 NeoForge 已切 Fabric Mixin（refmap/config 差异，见 01 票），JEP 447（super 前语句）影响构造注入写法。建议列 mixin 目标清单逐个对 vanilla 用法 diff。
+- [ ] 配置库（mechanical-rename，低风险）：仍 NightConfig 3.8.x + `ModConfigSpec` + `registerConfig`（CLIENT/COMMON/SERVER 语义与同步不变）；21.0 清理 breaking（`UnmodifiableConfigWrapper` 解耦、`defineList` 新增 GUI 默认值参数、`IConfigScreenFactory` 签名变）+ 内置 `ConfigurationScreen` 可选接入。GTM 自有 config 预计机械改动。
+
+## Answer
+
+API 差异盘点已完成并记录在本票的 `## Findings`。最终 spec 必须把网络、传输/Capability、客户端渲染列为行为级重写模块，把工具链、注册表、datagen、DataMap、事件、mixin 和配置列为机械改名或局部行为变更模块，并为每类模块补充文件范围与验收标准。

--- a/.scratch/port-26.1/issues/06-sync-workflow.md
+++ b/.scratch/port-26.1/issues/06-sync-workflow.md
@@ -1,0 +1,26 @@
+Type: grilling
+Status: resolved
+Blocked by: none
+
+## Question
+
+上游无 26.x 线（1.20.1 默认 + 1.21 并行）的前提下，rebase 跟踪如何操作化？
+
+## Notes
+
+- HITL：必须与人类 live 对话决议，调用 grilling + domain-modeling 两个 skill。
+- 待锁事项：git 基线布局（先 `git init` 锚定上游 1.20.1 某 tag 再开分支，锚点 tag 由本 ticket 定）、跟踪哪条线（默认 1.20.1 默认分支的修复如何转译到 26.1）、转译节拍（跟 release 跟 commit？）、私货隔离规则（当前零私货，规则先行）。
+- 上游 AI_POLICY.md 的披露与人类把关义务写进操作流。
+- 输出：决议 comment + 关闭 ticket，map 记一行；新术语同步 `CONTEXT.md`。
+
+## Answer
+
+同步方案按用户已确认的 rebase 跟踪策略固化如下：
+
+- 将 `GregTechCEu/GregTech-Modern` 作为 `upstream` remote；以实现开始时上游 `1.20.1` 的明确 commit SHA 作为 26.1.2 移植基线，并把该 SHA 写入移植记录。
+- 目标改动集中在独立的 26.1.2 / NeoForge 分支；上游 `1.20.1` 作为持续同步源，上游 `1.21` 仅作为 Forge→NeoForge 翻译手册，不直接作为目标基线。
+- 同步按上游可审阅的 commit group 进行：先把上游 1.20.1 更新 rebase 到移植分支，再逐组将语义变化翻译到 26.1.2，随后执行完整构建、数据生成、GameTest 和干净服务端验证。不得把 1.20.1 commit 直接当作可编译 cherry-pick。
+- MUI 作为本项目独立模块/依赖边界维护；上游 GTM 同步只处理 GTM 代码，避免把 MUI 移植改动混入上游同步提交。
+- 当前基线零私货；以后新增功能必须进入独立提交组，注明是否需要向上游回移。上游贡献遵守仓库 `AI_POLICY.md`：披露 AI 工具和辅助范围，提交前由人类理解、审阅并编辑。
+
+本票的结论是同步操作流，不要求本阶段创建 git remote 或提交；实际 git 初始化、分支和首个基线 SHA 属于实施计划的基础设施票。

--- a/.scratch/port-26.1/issues/07-spec-assembly.md
+++ b/.scratch/port-26.1/issues/07-spec-assembly.md
@@ -1,0 +1,17 @@
+Type: task
+Status: resolved
+Blocked by: 01, 02, 03, 04, 05, 06
+
+## Question
+
+汇总 01–06 全部决议，写出 AFK agent 可直接执行的移植 spec（`.scratch/port-26.1/spec.md`）：模块任务 + 版本坐标 + 验收标准 + 砍件范围 + 同步操作流，人类 review 后关闭本轮。
+
+## Notes
+
+- 先读 map 全文与 01–06 每个 ticket 的决议（含 `## Findings` / resolution comment），决议冲突时以更新者为准并在 spec 顶部显式标注。
+- Spec 粒度：每个模块任务可独立交给一个 agent session（含输入文件范围、目标坐标、完成标准）；版本坐标表直接可用；砍件范围精确到文件/接口。
+- 完成后决议 comment + 关闭 ticket，map 的 Decisions so far 记一行（指回 spec.md）。
+
+## Answer
+
+已根据 01–06 的研究和用户确认生成 `.scratch/port-26.1/spec.md`，并将代码实现拆成独立、可并行但带阻塞关系的实施计划票。spec 的验收 seam 是现有 Gradle build/data/GameTest/clean runtime 生命周期；本轮只发布计划，不执行移植。

--- a/.scratch/port-26.1/issues/08-toolchain-baseline.md
+++ b/.scratch/port-26.1/issues/08-toolchain-baseline.md
@@ -1,0 +1,26 @@
+Type: task
+Status: ready-for-agent
+Blocked by: none
+
+## Question
+
+建立 MC 26.1.2 + NeoForge 26.1.2.x 的可重复构建基线，并为后续实施票提供同步源和 Gradle 验收入口。
+
+## Context
+
+主 spec：[`spec.md`](../spec.md)。依赖事实：[`02-dep-pinning.md`](02-dep-pinning.md)。同步决议：[`06-sync-workflow.md`](06-sync-workflow.md)。
+
+## Work
+
+- 初始化或接入 upstream remote，并记录上游 `1.20.1` 基线 commit SHA；建立独立的 26.1.2 port 分支。
+- 将 Gradle、Java、ModDevGradle、NeoForge、Mojang mappings、版本目录和 repository 配置改为目标坐标。
+- 更新 mod metadata、loader、Minecraft version、run configuration、game-test namespace、data-generation run 和 mixin/toolchain 配置。
+- 接入 Registrate `MC26.1-1.5.0`、Configuration `4.1.2+26.1.2` 和已确认的 Maven repositories；禁止旧 1.20.1 Forge 坐标通过隐式 carry-over 解析。
+- 让空改动或最小 bootstrap 在目标 toolchain 上完成依赖解析与基础编译，作为后续票的共同起点。
+
+## Acceptance
+
+- 目标 Java/Gradle/NeoForge 版本可被 Gradle 解析，且 build 不再以 1.20.1 Forge 为运行时目标。
+- clean server、clean client、data generation 和 GameTest server 的运行配置均能生成。
+- upstream baseline SHA、目标 NeoForge 版本和依赖解析结果有可审阅记录。
+- 未完成 GTM API 迁移时允许源代码编译失败，但失败必须来自已知旧 API，而不是工具链或依赖坐标错误。

--- a/.scratch/port-26.1/issues/09-mui-port.md
+++ b/.scratch/port-26.1/issues/09-mui-port.md
@@ -1,0 +1,25 @@
+Type: task
+Status: ready-for-agent
+Blocked by: 08
+
+## Question
+
+将 ModularUI-Modern `1.21.1` 分支完整移植到 MC 26.1.2 / NeoForge，并以仓库内独立 Gradle 模块供 GTM 使用。
+
+## Context
+
+主 spec：[`spec.md`](../spec.md)。路线决议：[`03-mui-config-decision.md`](03-mui-config-decision.md)。上游版本参照：[`01-upstream-121-playbook.md`](01-upstream-121-playbook.md)。
+
+## Work
+
+- 将 `1.21.1` 分支作为完整源码基线，迁移其构建工具链、公共 API、widget、drawable、screen、value sync、menu、recipe-viewer 和 loader 集成。
+- 将 MUI 26.1.2 目标作为仓库内独立模块，保持 `brachy.modularui` 的公开包/API 边界；GTM 不复制 MUI 内部实现。
+- 迁移 MUI 自身的 NeoForge/MC API、渲染、网络和 datagen 触点；移除对 1.21.1 专用 API 的残留引用。
+- 让 GTM 的 cover、machine screen、recipe viewer、widget 和同步代码消费该模块，不为当前 GTM 用量制作缩减版替代 API。
+
+## Acceptance
+
+- MUI 模块可以独立编译并产出可被 GTM 消费的 artifact/project dependency。
+- GTM 当前所有 `brachy.modularui` 引用完成解析，代表性 machine、cover、recipe-viewer panel 可构造。
+- MUI API 的 screen/widget/value-sync/recipe-viewer smoke tests 通过；不能依赖被砍的 EMI、Create、Embeddium 或 Oculus。
+- clean client 能打开至少一个 GTM machine/cover UI，不发生 classloading、渲染或网络同步崩溃。

--- a/.scratch/port-26.1/issues/10-core-neoforge-api.md
+++ b/.scratch/port-26.1/issues/10-core-neoforge-api.md
@@ -1,0 +1,26 @@
+Type: task
+Status: ready-for-agent
+Blocked by: 08
+
+## Question
+
+完成 GTM 公共初始化、Forge→NeoForge 基础 API、事件总线、注册表和 capability registration 迁移，使其他功能票有稳定的目标 API 基础。
+
+## Context
+
+主 spec：[`spec.md`](../spec.md)。迁移参照：[`01-upstream-121-playbook.md`](01-upstream-121-playbook.md)。差异清单：[`05-api-gap-inventory.md`](05-api-gap-inventory.md)。
+
+## Work
+
+- 迁移 mod entrypoint、mod bus/game bus、生命周期、side checks、server lifecycle、client event 和 event subscriber。
+- 迁移 NeoForge package/import、registry keys、DeferredRegister、custom registry creation、registry freeze/sync 和 holder lookup。
+- 迁移 GTM 自有 capability registration 与公共 capability helper 的 NeoForge 边界；保留 GTM 的领域接口，不把第三方 API 泄漏进所有业务代码。
+- 更新基础 Minecraft/NeoForge 类型、ResourceLocation、level/random、holder 和 loader 变化，处理 26.1 mappings 的机械改名。
+- 让未迁移模块以最小方式可编译或清晰地暴露后续模块的 API 错误，不改变 GTM 领域行为。
+
+## Acceptance
+
+- clean server 能完成 GTM mod construction、registry registration 和 common initialization，失败不得来自旧 Forge bus/registry class。
+- 自有注册表、物品、方块、流体、block entity、menu、recipe type 和 capability key 能完成注册并可被 lookup。
+- dedicated server 不加载 client-only 类；现有测试初始化入口能在目标 game-test server 中发现。
+- 迁移记录列出无法机械替换的 API，并将它们转入 11–14 对应票，而不是留下隐式 TODO。

--- a/.scratch/port-26.1/issues/11-data-and-datagen.md
+++ b/.scratch/port-26.1/issues/11-data-and-datagen.md
@@ -1,0 +1,26 @@
+Type: task
+Status: ready-for-agent
+Blocked by: 10
+
+## Question
+
+迁移 GTM 的 recipe、ingredient、codec、datapack registry、loot、tags、models、data maps 和 datagen，使生成资源能被 MC 26.1.2 加载。
+
+## Context
+
+主 spec：[`spec.md`](../spec.md)。API 差异：[`05-api-gap-inventory.md`](05-api-gap-inventory.md)。当前数据/注册约定也见 [`01-upstream-121-playbook.md`](01-upstream-121-playbook.md)。
+
+## Work
+
+- 迁移 `GatherDataEvent`、client/server data providers、datapack built-in entries 和 data generation run。
+- 将 NBT-sensitive item/fluid ingredients、recipe serializers 和 validation 迁移到 Data Component、Holder、codec 和 StreamCodec 语义。
+- 将 ore vein、bedrock ore、bedrock fluid 等数据驱动注册迁移到目标 datapack registry，并移除旧同步包依赖。
+- 迁移 loot entry/function/condition 的 MapCodec 注册、loot validation、tags 目录语义、data maps、model/item model 生成和资源命名。
+- 保持 GTM recipe matching、材料数据、生成概率、loot 结果和自定义资源内容不变。
+
+## Acceptance
+
+- data generation 完成且生成资源在目标 dedicated server load 阶段无 codec、registry、tag、loot 或 data component 错误。
+- 代表性材料、矿脉、机器 recipe、NBT/Data Component ingredient、loot table 和 custom registry round-trip 测试通过。
+- 现有 recipe serializer/lookup/GameTest 回归测试在目标 toolchain 上通过。
+- 生成资源不依赖被砍的第三方 integration。

--- a/.scratch/port-26.1/issues/12-transfer-capabilities.md
+++ b/.scratch/port-26.1/issues/12-transfer-capabilities.md
@@ -1,0 +1,26 @@
+Type: task
+Status: ready-for-agent
+Blocked by: 10
+
+## Question
+
+迁移 GTM 的 item/fluid/energy transfer 和 capability 边界到 NeoForge 26.1.2，同时保持机器、管道、线缆、cover 和外部自动化行为。
+
+## Context
+
+主 spec：[`spec.md`](../spec.md)。重点研究：[`05-api-gap-inventory.md`](05-api-gap-inventory.md)。现有 machine/cover/capability 行为测试是主要 prior art。
+
+## Work
+
+- 将 Forge capability exposure、LazyOptional/provider、ForgeCapabilities 和旧 handler 访问改为目标 NeoForge capability/transfer model。
+- 评估并迁移 ResourceHandler、EnergyHandler、transaction、snapshot/rollback、side access 和 context 语义。
+- 在 GTM 自有 transfer API 与 NeoForge API 之间建立集中适配边界，避免所有机器和 cover 直接散落 target API 迁移。
+- 逐类迁移 item bus、fluid pipe、energy cable、machine ability、cover handler、external capability provider 和 compatibility wrappers。
+- 保持 simulate/execute、insert/extract、capacity、side、transaction failure 和 invalidation 语义。
+
+## Acceptance
+
+- 现有 cover、machine part、pipe、energy 和 AE2 相关行为测试通过，且增加代表性 transaction commit/rollback 测试。
+- item/fluid/energy 在空、满、部分容量、模拟和执行场景下结果与 1.20.1 领域行为一致。
+- 外部 NeoForge capability 查询可发现 GTM 支持的能力；不存在旧 Forge capability class 的 runtime linkage。
+- dedicated server 和 GameTest server 均不触发 client-only capability/provider 加载。

--- a/.scratch/port-26.1/issues/13-networking.md
+++ b/.scratch/port-26.1/issues/13-networking.md
@@ -1,0 +1,26 @@
+Type: task
+Status: ready-for-agent
+Blocked by: 10
+
+## Question
+
+将 GTM 的 SimpleChannel/FriendlyByteBuf 网络协议迁移为 NeoForge 26.1.2 CustomPacketPayload、Type、StreamCodec 和 payload handler，并恢复所有机器、GUI、cover、recipe 和同步消息。
+
+## Context
+
+主 spec：[`spec.md`](../spec.md)。网络差异：[`05-api-gap-inventory.md`](05-api-gap-inventory.md) 与 [`01-upstream-121-playbook.md`](01-upstream-121-playbook.md)。
+
+## Work
+
+- 为每个消息族定义 payload type、StreamCodec、方向、handler thread、可选/必需协商和错误处理。
+- 将 payload registration 接入 `RegisterPayloadHandlersEvent` 及 26.1.2 client-side handler 生命周期。
+- 迁移服务器到客户端、客户端到服务器和双向消息，覆盖 machine UI sync、cover sync、recipe sync、research、tooltips 和 integration messages。
+- 处理目标 payload 大小限制、连接生命周期、无效数据和旧世界/旧客户端拒绝策略。
+- 清理 SimpleChannel、NetworkDirection、旧 packet distributor 和旧 Forge network import。
+
+## Acceptance
+
+- 每个消息族至少有 codec round-trip test；代表性 GUI/machine sync 在 GameTest 或集成运行中恢复。
+- clean client/server 连接和打开 GTM UI 不因 payload registration 或 handler thread 错误崩溃。
+- 无旧 SimpleChannel/FriendlyByteBuf packet registration 残留作为 GTM 网络入口。
+- 无效、截断和错误方向 payload 被拒绝而不让 server/client 崩溃。

--- a/.scratch/port-26.1/issues/14-client-rendering.md
+++ b/.scratch/port-26.1/issues/14-client-rendering.md
@@ -1,0 +1,26 @@
+Type: task
+Status: ready-for-agent
+Blocked by: 09, 10, 11, 13
+
+## Question
+
+迁移 GTM 的 client UI、实体/方块实体/物品渲染、粒子、动态高亮、shader 触点和 mixin，使 vanilla 26.1.2 client 可启动并显示核心 GTM 内容。
+
+## Context
+
+主 spec：[`spec.md`](../spec.md)。渲染/mixin 差异：[`05-api-gap-inventory.md`](05-api-gap-inventory.md)。MUI 依赖：[完整 MUI 移植票](09-mui-port.md)。
+
+## Work
+
+- 迁移 entity render state、block entity render state、GUI render state、SubmitNodeCollector、item special model、particle、overlay、tooltip 和 dynamic highlight API。
+- 将 GTM machine screen、cover screen、recipe viewer、multiblock preview 和 MUI-backed widgets 接到目标 client lifecycle。
+- 迁移或删除失效的 Embeddium/Oculus/Create client hooks；目标基线以 vanilla client 为准，不把 Sodium/Iris 作为硬依赖。
+- 审核所有 client mixin target、refmap、injection point、compatibility level 和 side-only class。
+- 修复颜色、深度、资源解析、模型烘焙、shader JSON 和动态 buffer 在两阶段渲染中的行为。
+
+## Acceptance
+
+- clean client 启动并能打开代表性 machine/cover/recipe-viewer UI。
+- 代表性 machine block entity、pipe/cable、item model、particle、tooltip、multiblock preview 和 highlight 无加载崩溃。
+- mixin 应用日志无失效目标；被砍集成的 mixin 不再参与加载。
+- 在 vanilla 26.1.2 client 下完成手动 smoke check；若启用 Sodium/Iris，只作为额外兼容验证，不得成为核心验收前置。

--- a/.scratch/port-26.1/issues/15-integrations-and-cuts.md
+++ b/.scratch/port-26.1/issues/15-integrations-and-cuts.md
@@ -1,0 +1,26 @@
+Type: task
+Status: ready-for-agent
+Blocked by: 08, 10, 11
+
+## Question
+
+接入已核验的 26.1.2 third-party integration，并彻底移除没有目标构件的 optional integration，确保核心 mod 在依赖缺席时仍能运行。
+
+## Context
+
+主 spec：[`spec.md`](../spec.md)。依赖研究：[02-dep-pinning.md](02-dep-pinning.md)。砍件范围：[04-cut-list-scope.md](04-cut-list-scope.md)。
+
+## Work
+
+- pin 并接入 JEI、REI、Jade、Curios、AE2、AE2WTLib、KubeJS/Rhino/Architectury、FTB、CC:T、Xaero、JourneyMap、KotlinForForge、ResourcefulLib、Bookshelf、ModernFix、Spark、JAVD 和 Trenzalore。
+- 对 JourneyMap 使用 file `8768945`，并验证 API snapshot 与 runtime 构件的兼容性。
+- 移除官方 EMI、Create/Ponder/Flywheel、Embeddium/Oculus、GameStages、Observable、Argonauts、Heracles 和 WorldStripper 的 dependency、metadata、run config、mixin 和 GTM integration。
+- 保持可选依赖检测隔离；optional integration 初始化失败不能阻断 core registry、server 或 data generation。
+- 保留 JEI/REI 双 recipe-viewer 设计，但将 runtime 选择限制在可解析的 26.1.2 artifacts。
+
+## Acceptance
+
+- 目标依赖可解析到 26.1.2/NeoForge 坐标；旧 1.20.1 file ID 不会被当作目标版本使用。
+- 每个保留 integration 在存在时完成初始化或至少通过 compile/runtime smoke；不存在时 core GTM 仍能启动。
+- 被砍 integration 的源、metadata、mixin 和 dependency 不再参与编译或 runtime discovery。
+- JourneyMap、AE2、JEI/REI、Jade、KJS、FTB 和 CC:T 的代表性 integration path 有验证记录。

--- a/.scratch/port-26.1/issues/16-validation.md
+++ b/.scratch/port-26.1/issues/16-validation.md
@@ -1,0 +1,26 @@
+Type: task
+Status: ready-for-agent
+Blocked by: 09, 11, 12, 13, 14, 15
+
+## Question
+
+用现有 Gradle lifecycle 对完整移植做 build、数据生成、GameTest、dedicated server、client 和 optional dependency absence 验收，并补足行为回归测试。
+
+## Context
+
+主 spec：[`spec.md`](../spec.md)。测试决策基于当前 `src/test` 中的 recipe、machine、cover、AE2 和 GameTest prior art。
+
+## Work
+
+- 执行目标 toolchain 的 compile/package/build、data generation、GameTest server、clean server 和 clean client。
+- 运行并修复现有 recipe serializer/lookup、overclock、machine part、cover、capability、AE2 pattern buffer 和 stress tests。
+- 补充网络 codec、Data Component ingredient、datapack registry、loot/tag/data map、transfer transaction、MUI UI smoke 和 optional integration absence tests。
+- 在没有 EMI/Create/Embeddium/Oculus/GameStages 等 cut mod 的 classpath 下运行 core validation。
+- 记录每个失败是工具链、依赖坐标、机械 API、行为语义还是测试环境问题，并回指对应计划票。
+
+## Acceptance
+
+- build/package、data generation、GameTest server 和 clean server 成功。
+- clean client 能启动并完成代表性 UI/render smoke；没有旧 Forge/removed integration linkage。
+- 现有测试和新增核心行为测试通过，或有明确、已批准的 target-version 行为差异记录。
+- 在缺失所有 cut integration 时，core GTM 仍可构建、启动和运行代表性 GameTest。

--- a/.scratch/port-26.1/issues/17-sync-and-release.md
+++ b/.scratch/port-26.1/issues/17-sync-and-release.md
@@ -1,0 +1,26 @@
+Type: task
+Status: ready-for-agent
+Blocked by: 08, 16
+
+## Question
+
+固化上游同步、CI 和 26.1.2 发布元数据，使移植分支可长期 rebase 跟踪并产出不会误标为 1.20.1 Forge 的构建物。
+
+## Context
+
+主 spec：[`spec.md`](../spec.md)。同步决议：[`06-sync-workflow.md`](06-sync-workflow.md)。仓库 AI policy：[`AI_POLICY.md`](../../../AI_POLICY.md)。
+
+## Work
+
+- 将 upstream `1.20.1` 的同步流程、commit group 翻译规则、基线 SHA 记录和 MUI/GT 分离规则写入贡献/维护文档。
+- 更新 CI matrix、Java setup、Gradle cache、build/test/data tasks、artifact naming、mod metadata 和 release checks。
+- 确认 CI 不会因为旧版本目录、旧 loader 名称或旧 file ID 误构建出 1.20.1 artifact。
+- 生成 26.1.2/NeoForge 发行候选 artifact，并记录依赖、客户端/服务端启动和测试结果；实际上传发布平台不属于本票必须动作。
+- 确认后续向上游提案时遵守 AI disclosure 和 human review 要求。
+
+## Acceptance
+
+- CI 使用与本地相同的 build/data/GameTest 验收入口，并在失败时保留有用日志。
+- 产物、metadata、filename 和 release notes 明确标注 MC 26.1.2 / NeoForge。
+- 维护者可以按照文档从 upstream `1.20.1` 更新、翻译 commit group、运行验证并保留可审阅历史。
+- 最终 PR 的 changed files、依赖坐标和验证结果可与本 spec 和计划票逐项对应。

--- a/.scratch/port-26.1/map.md
+++ b/.scratch/port-26.1/map.md
@@ -1,0 +1,52 @@
+## Destination
+
+一份 AFK agent 可直接执行的《GTM 1.20.1 Forge → MC 26.1.2 / NeoForge 26.x 移植 spec》及其实施 task graph：版本坐标全钉死、API 差异清单、砍件清单与牵连范围、模块任务 + 验收标准、与上游双线并行的同步操作流。spec 已发布到 [`spec.md`](spec.md)；动手移植由 08–17 计划票执行。
+
+## Notes
+
+- Domain：MC mod 移植（GregTech Modern，`src/main` 下 1725 个 java 文件，单体 Forge 工程，gtceu 8.0.0）。
+- 目标坐标：MC 26.1.2 + NeoForge 26.1.2.x 最新 stable（见 CONTEXT.md「目标坐标」）。
+- 基线：当前 fork 相对上游 [GregTechCEu/GregTech-Modern](https://github.com/GregTechCEu/GregTech-Modern) 1.20.1 线零改动；上游无 26.x 线（仅 1.20.1 + 1.21 双线并行），故基线策略 = 从手头 1.20.1 移植，以上游 1.21 分支为 Forge→NeoForge 参照实现。
+- 依赖政策：找全或砍；硬依赖可自移植；无阻塞性依赖（见 CONTEXT.md）。
+- Spec 读者 = AFK agent：决议必须写到"可执行"粒度（坐标、范围、验收标准），不要只写方向。
+- 各 session 按 ticket 的 Type 调用对应 skill（research / grilling + domain-modeling / prototype）；经过 `CONTEXT.md` 术语时用其词汇，凝固新术语就地更新 `CONTEXT.md`。
+- 本仓库无 `.git`：研究阶段发现记进 ticket 的 `## Findings`；实施阶段由 08 票初始化/接入 upstream，并记录移植基线。
+- 上游有 AI_POLICY.md：凡涉及向 GregTechCEu 上游贡献的内容，执行者须遵守其披露与人类把关义务。
+
+## Decisions so far
+
+- [26.x 依赖版本钉死](issues/02-dep-pinning.md)：目标保持 MC 26.1.2 / NeoForge 26.1.2.x；Registrate 直接消费 `MC26.1-1.5.0`，JourneyMap 保留 file `8768945`，MUI 进入完整移植路线。
+- [上游 1.21 Forge→NeoForge 翻译手册](issues/01-upstream-121-playbook.md)：上游 1.21 只作迁移参照；无上游 26.x 分支，实际基线仍是当前零改动的 1.20.1。
+- [MC 26.1.2 API 差异盘点](issues/05-api-gap-inventory.md)：网络、传输/Capability、客户端渲染是行为级重写；其余区域按机械迁移或局部行为变更拆分。
+- [MUI 与 Configuration 路线裁决](issues/03-mui-config-decision.md)：完整移植 MUI `1.21.1` 分支到本项目；Configuration 直接使用 `4.1.2+26.1.2`，Registrate 使用已发布的 `MC26.1-1.5.0`。
+- [砍件清单与代码牵连面](issues/04-cut-list-scope.md)：移除官方 EMI、Create/Ponder/Flywheel、Embeddium/Oculus、GameStages 及无 26.1.2 构件的 dev runtime；不保留空壳 API，MUI 不砍。
+- [上游同步操作流](issues/06-sync-workflow.md)：以明确的上游 `1.20.1` SHA 为源，26.1 分支独立 rebase，按 commit group 翻译并验证；1.21 只作参考。
+- [移植 spec 总装](issues/07-spec-assembly.md)：spec 已生成，实施计划票已拆分到 08–17。
+
+## Implementation plan
+
+实施阶段使用同一目录下的计划票；`Blocked by` 是实现前置，不是线性步骤。最先可取的是 08「移植分支与工具链基线」；08 完成后，09「完整 MUI 移植」与 10「核心 NeoForge API」可并行。
+
+- [08 移植分支与工具链基线](issues/08-toolchain-baseline.md)：无阻塞；建立目标坐标、Java/Gradle/MDG、仓库、metadata、run config 和同步基线。
+- [09 完整 MUI 26.1.2 移植](issues/09-mui-port.md)：阻塞于 08；从 ModularUI-Modern 1.21.1 分支完整迁移并让 GTM 消费。
+- [10 核心 NeoForge API 与注册系统](issues/10-core-neoforge-api.md)：阻塞于 08；迁移入口、总线、注册表、能力注册、包名与公共初始化。
+- [11 数据、配方与 datagen](issues/11-data-and-datagen.md)：阻塞于 10；迁移 Data Component、datapack registry、loot、tags、recipe codec 和生成链路。
+- [12 传输与 Capability 语义](issues/12-transfer-capabilities.md)：阻塞于 10；迁移物品/流体/能量/自有 capability 边界及机器、管道、cover 行为。
+- [13 网络与同步协议](issues/13-networking.md)：阻塞于 10；将 SimpleChannel 迁移为 payload/StreamCodec，并恢复 GUI、机器、配方同步。
+- [14 客户端渲染、MUI UI 与 mixin](issues/14-client-rendering.md)：阻塞于 09, 10, 11, 13；迁移两阶段渲染、屏幕、BER、动态高亮、mixin 和 MUI 集成。
+- [15 保留集成与砍件清理](issues/15-integrations-and-cuts.md)：阻塞于 08, 10, 11；接入已核验依赖，删除砍件及其牵连模块，保留无可选依赖时的核心行为。
+- [16 测试、数据生成与运行时验收](issues/16-validation.md)：阻塞于 09, 11, 12, 13, 14, 15；执行全量 Gradle 验收并补行为测试。
+- [17 上游同步与发布准备](issues/17-sync-and-release.md)：阻塞于 08, 16；固化 rebase 流程、CI、版本元数据和 26.1.2 发布产物检查。
+
+## Not yet specified
+
+- 上游 1.20.1 之外新功能的长期维护策略。
+- 被砍依赖的功能回补（如下游世界需要）。
+- 26.1.2 之后的 MC/NeoForge 版本升级。
+
+## Out of scope
+
+- 实际动手移植执行（本次 destination 止于 spec）。
+- 上游 1.21 分支自身的演进（上游的事，我们只读它）。
+- 被砍依赖的功能回补实现。
+- 1.20.1 Forge 线的继续维护。

--- a/.scratch/port-26.1/spec.md
+++ b/.scratch/port-26.1/spec.md
@@ -1,0 +1,112 @@
+Status: ready-for-agent
+
+# GTM 26.1.2 NeoForge 移植 Spec
+
+## Problem Statement
+
+当前仓库是 GregTech Modern（GTM）的 MC 1.20.1 Forge 基线，相对上游 `GregTechCEu/GregTech-Modern` 的 1.20.1 线没有本地改动。用户希望把它移植到 Minecraft 26.1.2 + NeoForge 26.1.2.x，同时能够持续跟踪上游 1.20.1 线的修复和演进。
+
+移植不能只停留在替换 Forge 包名：目标版本同时带来 Java/Gradle 工具链变化、NeoForge API 变化、网络 payload 重写、传输与 capability 事务模型、Data Component、datapack registry、datagen、两阶段客户端渲染和 mixin 目标变化。当前依赖列表中还有一些依赖没有 26.1.2 构件，ModularUI 没有 26.1.2 发布版，但 GTM 大量 UI、recipe viewer 和 cover 代码直接使用它。
+
+## Solution
+
+建立一个 MC 26.1.2 + NeoForge 26.1.2.x 的 GTM 移植分支，并把 ModularUI-Modern 的 1.21.1 分支完整移植为仓库内独立模块。GTM 以已核验的 26.1.2 依赖为目标坐标，移除没有官方 26.1.2 支持的可选集成，保留核心机器、材料、配方、数据生成、UI、网络同步和已确认可用的第三方集成。
+
+实现按以下 task graph 执行：先建立工具链和上游同步基线；随后并行处理完整 MUI 模块与核心 NeoForge API；再分别迁移数据、传输、网络、客户端渲染和集成；最后通过现有 Gradle build、data generation、GameTest server、clean client/server 运行入口完成验收。
+
+上游没有 MC 26.x 分支。`1.20.1` 分支是持续同步源，`1.21` 分支只作为 Forge→NeoForge 的翻译手册。同步时不能直接 cherry-pick 1.20.1 提交到 26.1.2 分支，必须按 commit group 翻译、验证并保持移植分支的提交边界清晰。
+
+## User Stories
+
+1. As a GTM player, I want the mod to load on Minecraft 26.1.2 with NeoForge, so that I can use GTM in a current 26.1.2 modpack.
+2. As a server operator, I want a dedicated server to start with GTM without client-only class failures, so that the same build works in a server environment.
+3. As a mod developer, I want the Gradle project to resolve the exact 26.1.2 and NeoForge dependencies, so that local and CI builds are reproducible.
+4. As a mod developer, I want the project to use the Java and Gradle toolchain required by MC 26.1.2, so that compilation does not depend on an accidental local setup.
+5. As a GTM maintainer, I want a complete ModularUI API available inside the repository, so that existing GTM screens, widgets, recipe viewers, covers and synchronization code do not need to be reduced to a small substitute API.
+6. As a GTM maintainer, I want the MUI module to remain independently bounded from GTM code, so that future MUI fixes can be reviewed and updated separately.
+7. As a GTM user, I want registered GTM items, blocks, fluids, machines, materials and custom registries to load normally, so that existing worlds and recipes can be opened after the port.
+8. As a GTM developer, I want NeoForge mod-bus and game-bus events to be registered through the target API, so that initialization order remains deterministic.
+9. As a GTM developer, I want custom registries and deferred registries to be created and frozen correctly, so that registry synchronization does not fail at startup.
+10. As a GTM user, I want existing recipes and recipe ingredients to retain their matching behavior, so that machines produce the same results after the port.
+11. As a GTM developer, I want NBT-based ingredient behavior represented through the target Data Component and codec APIs, so that recipes remain data-driven on 26.1.2.
+12. As a pack author, I want ore veins, bedrock ores, bedrock fluids and other datapack registries to be generated in the target format, so that custom world-generation data remains extensible.
+13. As a pack author, I want generated tags, loot tables, recipes and models to be valid for 26.1.2, so that data generation produces loadable resources.
+14. As a GTM user, I want item, fluid and energy transport in machines, pipes and covers to preserve insertion, extraction, simulation and transaction semantics, so that automation networks behave as before.
+15. As a GTM developer, I want the GTM capability boundary to adapt to NeoForge capabilities and the new transfer API, so that external mods can still discover supported machine capabilities.
+16. As a GTM user, I want machine GUI state, cover state, recipe state and server-to-client updates to synchronize reliably, so that screens do not display stale or invalid data.
+17. As a GTM developer, I want all network messages to use the target payload and `StreamCodec` model, so that networking remains compatible with NeoForge 26.1.2.
+18. As a GTM user, I want machine blocks, block entities, items, entities and GUI elements to render correctly on a vanilla 26.1.2 client, so that the port does not depend on removed rendering mods.
+19. As a GTM developer, I want mixins to target the 26.1.2 classes and mappings, so that startup does not fail because of stale Forge, Embeddium or old vanilla targets.
+20. As a player using JEI, REI, Jade, AE2, AE2WTLib, KubeJS, FTB, CC:T, Curios, Xaero or JourneyMap, I want GTM integrations to load with the pinned 26.1.2 versions, so that supported interoperability remains available.
+21. As a pack author, I want unsupported optional integrations to be absent cleanly, so that GTM does not crash when EMI, Create, Embeddium, Oculus, GameStages or unavailable development tools are not installed.
+22. As a GTM user, I want the core mod to retain its behavior when optional integrations are absent, so that an optional dependency cannot become a hidden hard dependency.
+23. As a GTM developer, I want existing recipe, machine, cover, AE2 and GameTest behavior tests to run on the target toolchain, so that the port can detect semantic regressions rather than only compilation errors.
+24. As a GTM developer, I want data generation to run as a project-level verification seam, so that invalid codecs, registries, tags, loot and generated assets are caught before runtime testing.
+25. As a GTM developer, I want a clean server and clean client smoke test, so that side-only class loading, mod metadata, dependency declarations and startup registration are verified together.
+26. As an upstream maintainer, I want the port branch to record its upstream 1.20.1 commit baseline, so that future synchronization has an unambiguous source point.
+27. As an upstream maintainer, I want upstream fixes to be replayed as translated commit groups, so that the 26.1.2 branch can follow upstream without pretending that incompatible commits cherry-pick cleanly.
+28. As a contributor, I want implementation commits to keep MUI, GTM porting, dependency changes and optional integration removal separable, so that reviews and future rebases remain manageable.
+29. As a project maintainer, I want CI and publishing metadata to identify MC 26.1.2 and NeoForge correctly, so that generated artifacts cannot be mistaken for the 1.20.1 Forge line.
+30. As a project maintainer, I want AI-assisted contributions to follow the repository AI policy, so that upstream-facing work includes disclosure and human review.
+
+## Implementation Decisions
+
+- The target coordinate is Minecraft 26.1.2 with the latest verified stable NeoForge 26.1.2.x, currently `26.1.2.99`. The implementation must re-resolve the NeoForge release during bootstrap and record the exact resolved version.
+- The target toolchain uses Java 25, Gradle 9.1 or newer, the 26.1-compatible ModDevGradle plugin, and official Mojang mappings. Parchment must not remain as a 26.1 mapping dependency.
+- The GTM baseline is the current pristine 1.20.1 Forge source. The exact upstream `1.20.1` commit SHA used at bootstrap must be recorded before port changes begin.
+- The upstream `1.20.1` line is the synchronization source. The upstream `1.21` line is a migration reference only; it is not the 26.1.2 implementation base.
+- Synchronization uses an independent 26.1.2 port branch and translated commit groups. A source update is rebased into the port workflow, then manually translated and validated. MUI changes remain separate from GTM synchronization changes.
+- Registrate is consumed as `com.tterrag.registrate:Registrate:MC26.1-1.5.0` from `https://maven.gegy.dev/releases/`. The MC 26.2-only `26.2-1.6.0` release is not used.
+- Configuration is consumed as `dev.toma.configuration:configuration-neoforge:4.1.2+26.1.2` from the Toma Repsy repository, with its API and initialization behavior validated during the build.
+- MixinExtras is not added as a separate old Forge dependency when the target NeoForge toolchain already provides the required support. Any explicit mixin annotation processing still required by the port must use a 26.1-compatible artifact.
+- ModularUI-Modern is fully ported from its `1.21.1` branch into an independent Gradle module embedded in this repository. GTM consumes the module through a normal project dependency boundary, and the complete public API is preserved rather than replaced with GTM-specific stubs.
+- The MUI module must compile independently before GTM integration work is considered complete. GTM UI integration must retain current screen, widget, value-sync, menu, drawable and recipe-viewer behavior.
+- The pinned dependency set includes JEI `29.35.0.94`, REI `26.1.819+neoforge`, Jade `26.1.10`, Curios `15.0.0+26.1.2`, AE2 `26.1.11-beta`, AE2WTLib `26.1.1-beta`, KubeJS `26.1.2-8.0.4+neoforge`, Rhino `2101.2.8-build.91`, Architectury `20.0.12`, FTB Library `26.1.2.7`, FTB Teams `26.1.2.4`, FTB Quests `26.1.2.7`, FTB Chunks `26.1.2.8`, CC:T `v26.1.2-1.120.0`, Cloth Config `26.1.154`, Xaero Minimap `26.4.2`, Xaero WorldMap `1.45.0`, ModernFix `5.27.22+mc26.1.2`, KotlinForForge `6.3.0`, ResourcefulLib `4.0.1`, Bookshelf `26.1.2.15`, Spark `1.10.173`, JAVD/Trenzalore 26.1.x runtime files, and JourneyMap file `8768945`.
+- JourneyMap API uses the verified 26.1 snapshot coordinate while the runtime mod uses CurseForge file `8768945`; dependency resolution and startup must verify that the API and runtime are compatible.
+- Unverified carry-over file IDs are not silently retained as target pins. Observable, Argonauts, Heracles and WorldStripper are removed from the default target runtime because no 26.1.2 artifact was verified.
+- Official EMI, Create/Ponder/Flywheel, Embeddium/Oculus and GameStages are cut from the target. Chapters is not introduced as an automatic replacement. The corresponding dependencies, metadata, run configurations and GTM integration modules are removed or isolated.
+- No empty compatibility stubs are kept for cut integrations. Core GTM code must compile and run without them. JEI, REI, Jade, AE2, AE2WTLib, KubeJS, FTB, CC:T, Curios, Xaero and JourneyMap remain supported integration surfaces.
+- The core API migration changes Forge event bus, lifecycle, registry, capability, fluid, energy, item, server lifecycle and client event boundaries to their NeoForge equivalents. Initialization order and side safety are part of the behavior contract.
+- Custom registries and data-driven registries are migrated to the 26.1 NeoForge registration model. Ore veins, bedrock ores and bedrock fluids become valid datapack registries with generated data rather than legacy synchronization packets.
+- NBT-sensitive recipe ingredients are migrated to Data Component and codec-based representations. Recipe serialization must preserve matching, copying, validation and network behavior.
+- Loot, tags, data maps, models, recipes and datapack built-in entries are migrated to the 26.1 codec and datagen contracts. Loot type/function/condition registrations use the target MapCodec model.
+- GTM's item, fluid and energy transport behavior is preserved at its public semantic boundary while implementation adapts to NeoForge's ResourceHandler, EnergyHandler and transaction model. Existing machine, pipe, cover and external capability behavior must be tested after adaptation.
+- Every network message is migrated from SimpleChannel/FriendlyByteBuf conventions to CustomPacketPayload, Type, StreamCodec and payload handler registration. Direction, threading, optionality, size limits and server/client execution are explicit for each message family.
+- Client work covers entity render state, block entity render state, GUI render state, special item models, particles, overlays, dynamic highlights and shader-compatible rendering. The first acceptance target is a vanilla 26.1.2 client; Embeddium/Oculus compatibility is not required.
+- Mixin configurations, compatibility targets and injection points are reviewed against 26.1.2 mappings. Stale Forge, Embeddium and removed third-party targets are deleted rather than left to fail at runtime.
+- The project-level Gradle lifecycle is the highest testing seam: compilation/package, data generation, GameTest server, clean dedicated server, and clean client. New tests should attach to these existing seams rather than inventing a parallel harness.
+- Existing recipe, machine, cover, AE2 and GameTest tests are ported before being expanded. New tests cover network codec round trips, capability/transfer semantics, registry/datagen loading, MUI smoke behavior and optional-integration absence.
+- CI and publishing metadata must report MC 26.1.2, NeoForge and the new Java toolchain; the old 1.20.1 Forge metadata must not remain on the target branch.
+
+## Testing Decisions
+
+- A good test observes external behavior: a registry is present, a recipe matches, a machine transfers the expected amount, a packet reconstructs the expected state, a generated resource loads, or a client/server starts. Tests must not assert private helper structure merely to protect a chosen implementation.
+- The primary seam is the existing Gradle lifecycle. The implementation is complete only when the main build/package task, data generation run, GameTest server run, clean server run and clean client run all pass on the target toolchain.
+- The existing unit and GameTest suites are prior art. Recipe lookup, recipe serializer, overclocking, machine parts, covers, AE2 pattern buffers, capability helpers and stress tests should remain the regression baseline.
+- Core API and registry work is tested by build-time registration plus data generation and a clean server startup. This catches missing event subscribers, invalid registry keys, metadata errors and server-side class loading.
+- Data and codec work is tested by round-trip serialization, generated-resource loading and representative recipe/loot/tag/datapack registry tests. Tests must include Data Component-backed ingredients and datapack registry entries.
+- Transfer and capability work is tested through existing machine, pipe, cover and GameTest behavior, including simulated versus executed insertion/extraction, sided access, empty/full boundaries and transaction rollback/commit behavior.
+- Networking is tested at the codec and handler boundary. Each packet family needs a representative encode/decode round trip and a server/client behavior test where the current suite already has a suitable GameTest seam.
+- MUI is tested first as an independently compiling module, then through GTM UI smoke coverage: create a representative panel, open a representative machine/cover screen, synchronize a representative value, and render a representative recipe-viewer widget.
+- Client work is tested with clean client startup and representative render paths. Where a headless render assertion is impractical, the acceptance requirement is no crash, correct resource/model resolution and a manual smoke check recorded with the implementation result.
+- Optional integrations are tested in two modes: the supported dependency is present and initializes; the cut or absent dependency is absent and GTM still starts. No test may require a cut dependency to compile the core mod.
+- CI tests should run the same Gradle entry points as local validation, with dependency resolution failures reported as first-class failures rather than silently falling back to 1.20.1 artifacts.
+
+## Out of Scope
+
+- Actual implementation is not performed by this spec-writing task; implementation is represented by the plan tickets below.
+- A new upstream MC 26.x branch or upstream 1.21 branch maintenance is out of scope.
+- Reintroducing official EMI, Create/Ponder/Flywheel, Embeddium/Oculus or GameStages is out of scope.
+- Chapters-based GameStages replacement is out of scope until a separate compatibility decision is made.
+- Feature parity with unverified optional dev/runtime mods is out of scope.
+- Maintaining the 1.20.1 Forge line from the 26.1.2 branch is out of scope.
+- Publishing to CurseForge or Modrinth beyond preparing correct metadata and artifacts is out of scope for the core port plan.
+- MC 26.1.2 follow-up updates, MC 26.2 and later version ports are out of scope.
+
+## Further Notes
+
+- Domain vocabulary and resolved decisions live in [`CONTEXT.md`](../../CONTEXT.md).
+- Research and decision evidence lives in the [wayfinding map](map.md) and its closed tickets: [dependency pins](issues/02-dep-pinning.md), [translation manual](issues/01-upstream-121-playbook.md), [API gap inventory](issues/05-api-gap-inventory.md), [MUI decision](issues/03-mui-config-decision.md), [cut scope](issues/04-cut-list-scope.md) and [sync workflow](issues/06-sync-workflow.md).
+- The implementation task graph is listed in the map and described by tickets 08 through 17. Each ticket links back to this spec and states its own blocking relationship and acceptance criteria.
+- The repository has no git metadata at the time this spec was written. The first implementation ticket must initialize or attach the repository to the upstream remote and record the baseline commit before any port commit is created.
+- The repository AI policy requires disclosure of AI tooling and human understanding/review for any contribution, especially anything later proposed upstream.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+## Agent skills
+
+### Issue tracker
+
+Issues live as local markdown files under `.scratch/<feature>/`. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Default five-role vocabulary (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context layout: root `CONTEXT.md` + `docs/adr/`. See `docs/agents/domain.md`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,19 @@
+# CONTEXT.md
+
+GregTech Modern（GTM）1.20.1 Forge fork 向 MC 26.1.2 / NeoForge 26.x 移植工作的领域语言。只收术语，不收实现细节。
+
+## Glossary
+
+- **目标坐标**：MC 26.1.2（Mojang 新命名规则）+ NeoForge 26.1.2.x（取最新 stable，如 26.1.2.99 经证实存在；自称 .100 的需以 Maven 为准）。
+- **移植 spec**：本轮 wayfinding 的 destination。一份 AFK agent 可直接执行的文档：版本坐标全钉死、API 差异清单、砍件清单与范围、模块任务 + 验收标准、同步操作流。止于规划，不含动手移植。
+- **基线**：手头这份 fork，相对上游 `GregTechCEu/GregTech-Modern` 1.20.1 线**零改动**。移植起点，不是终点。
+- **上游双线**：上游长期并行的两个版本线——`1.20.1`（默认分支，Forge）与 `1.21`（MC 1.21.1 + NeoForge 21.1.248）。上游没有 26.x 线。
+- **rebase 跟踪**：与上游同步的策略。长期 rebase 上游、私货隔离、保持可合入上游的形状。在上游无 26.x 线的前提下，跟踪对象默认为 1.20.1 默认分支的修复（转译到 26.1），操作化细节由「同步操作流」ticket 锁定。
+- **依赖政策（找全或砍）**：30+ 兼容/运行时依赖尽可能找到 26.x 对应版本；找不到的暂时砍掉，不等。
+- **硬依赖**：缺了则移植在技术上无法成立的构建依赖（Registrate、MUI、MixinExtras、Configuration）。与兼容层不同：硬依赖若无官方版本，路线是**自己移植或找替代**，而不是砍，更不是无限期等。
+- **Registrate 坐标**：目标依赖 `com.tterrag.registrate:Registrate:MC26.1-1.5.0`，从 `maven.gegy.dev/releases` 消费；26.2 专用的 `26.2-1.6.0` 不属于本目标。
+- **MUI 移植**：完整移植 `ModularUI-Modern` 的 `1.21.1` 分支到本项目，保持独立模块边界，目标是让 GTM 继续使用完整 MUI API；不采用缩减为 GTM 实际引用最小集的策略。
+- **JourneyMap pin**：JourneyMap 使用 CurseForge file ID `8768945` 的 NeoForge 26.1.2 构件；API 侧使用 26.1 snapshot 坐标并在构建中验证。
+- **砍件**：按依赖政策被暂时砍掉的依赖（如 EMI、官方 Create、Embeddium、GameStages）。砍的是依赖坐标与其牵连代码，不是功能承诺；回补是 out of scope。
+- **阻塞性依赖**：本轮决议为**无**——没有"缺了就停下等"的项，硬依赖走自移植路线。
+- **翻译手册**：上游 1.20.1→1.21 分支的 Forge→NeoForge 迁移 diff，复用为 26.1 移植的参照实现。

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists: it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`**: read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal: either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders), but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,30 @@
+# Issue tracker: Local Markdown
+
+Issues and specs for this repo live as markdown files in `.scratch/`.
+
+## Conventions
+
+- One feature per directory: `.scratch/<feature-slug>/`
+- The spec is `.scratch/<feature-slug>/spec.md`
+- Implementation issues are one file per ticket at `.scratch/<feature-slug>/issues/<NN>-<slug>.md`, numbered from `01`, never a single combined tickets file
+- Triage state is recorded as a `Status:` line near the top of each issue file (see `triage-labels.md` for the role strings)
+- Comments and conversation history append to the bottom of the file under a `## Comments` heading
+
+## When a skill says "publish to the issue tracker"
+
+Create a new file under `.scratch/<feature-slug>/` (creating the directory if needed).
+
+## When a skill says "fetch the relevant ticket"
+
+Read the file at the referenced path. The user will normally pass the path or the issue number directly.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a file with one **child** file per ticket.
+
+- **Map**: `.scratch/<effort>/map.md` (the Notes / Decisions-so-far / Fog body).
+- **Child ticket**: `.scratch/<effort>/issues/NN-<slug>.md`, numbered from `01`, with the question in the body. A `Type:` line records the ticket type (`research`/`prototype`/`grilling`/`task`); a `Status:` line records `claimed`/`resolved`.
+- **Blocking**: a `Blocked by: NN, NN` line near the top. A ticket is unblocked when every file it lists is `resolved`.
+- **Frontier**: scan `.scratch/<effort>/issues/` for files that are open, unblocked, and unclaimed; first by number wins.
+- **Claim**: set `Status: claimed` and save before any work.
+- **Resolve**: append the answer under an `## Answer` heading, set `Status: resolved`, then append a context pointer (gist + link) to the map's Decisions-so-far in `map.md`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
## Scope\n\nImplements the local port spec at .scratch/port-26.1/spec.md. The implementation task graph is tracked in .scratch/port-26.1/map.md and tickets 08 through 17.\n\n## Target\n\n- Minecraft 26.1.2\n- NeoForge 26.1.2.x\n- Upstream base: 1.20.1 at 4c30877\n- MUI: complete ModularUI-Modern 1.21.1 port inside this repository\n\n## Validation\n\nBuild, data generation, GameTest server, clean server, clean client, integration presence/absence, and upstream synchronization checks will be added as implementation progresses.\n\nThe local markdown tracker has no GitHub issue numbers; this PR is the implementation surface for the spec and its plan tickets.