### PR TITLE
Fix FluidIngredient not working at all with multiple options in the values array

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/ingredient/FluidIngredient.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/ingredient/FluidIngredient.java
@@ -111,8 +111,9 @@ public class FluidIngredient implements Predicate<FluidStack> {
             return false;
         }
         for (FluidStack fluidStack : this.getStacks()) {
-            if (fluidStack.getFluid() != stack.getFluid()) continue;
-            return true;
+            if (fluidStack.getFluid().isSame(stack.getFluid())) {
+                return true;
+            }
         }
         return false;
     }


### PR DESCRIPTION
## What
...such as fluid tags with multiple entries.

## Implementation Details
Changed a loop that checks if all entries match to one that checks if any entry matches.

### AI Usage 
- [x] No AI driven tools were used for this pull request.
  
## Outcome
The code now works as intended.

## How Was This Tested
1. Installed a mod that adds a properly tagged fluid (I chose ad astra's oxygen because that's the first one that came to mind)
2. Ran recipes that require oxygen as an input
3. the `S(s) + 2O(g) -> SO2(g)` chemical reactor recipe still worked.

## Additional Information
_**How has this worked at all for the last 3 years?????**_