### PR TITLE
Fix Bucket Mode Toggle on Pump Covers, and uncap Supply/KeepExact limits on Regulators

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/cover/FluidRegulatorCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/FluidRegulatorCover.java
@@ -179,7 +179,7 @@ public class FluidRegulatorCover extends PumpCover {
         GTMuiCoverUtil.addTransferModeRow(column, transferMode);
 
         column.child(
-                GTMuiWidgets.createIntInputWithBucketMode(transferSize, transferBucketMode, () -> maxFluidTransferRate)
+                GTMuiWidgets.createIntInputWithBucketMode(transferSize, transferBucketMode, () -> Integer.MAX_VALUE)
                         .setEnabledIf($ -> shouldShowTransferSize()));
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/common/mui/GTMuiWidgets.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/mui/GTMuiWidgets.java
@@ -574,8 +574,8 @@ public class GTMuiWidgets {
                                                                EnumSyncValue<BucketMode> bucketModeSyncValue,
                                                                IntSupplier maxMB) {
         StringSyncValue formattedValue = new StringSyncValue(
-                () -> String.valueOf(intSyncValue.getValue()),
-                (v) -> intSyncValue.setValue(Integer.parseInt(v), true,
+                () -> formattedBucketValue(intSyncValue.getIntValue(), bucketModeSyncValue.getValue()),
+                (v) -> intSyncValue.setValue(bucketsFromFormattedValue(v, bucketModeSyncValue.getValue()), true,
                         true))
                 .allowC2S();
 
@@ -628,6 +628,20 @@ public class GTMuiWidgets {
                         .background(GTGuiTextures.BUTTON)
                         .stateOverlay(0, BucketMode.BUCKET.icon.asIcon().size(16))
                         .stateOverlay(1, BucketMode.MILLI_BUCKET.icon.asIcon().size(16)));
+    }
+
+    public static String formattedBucketValue(int millibuckets, BucketMode bucketMode) {
+        if (bucketMode == BucketMode.MILLI_BUCKET) return String.valueOf(millibuckets);
+        StringBuilder buckets = new StringBuilder(String.format("%04d", millibuckets));
+        buckets.insert(buckets.length() - 3, '.');
+        return buckets.toString();
+    }
+
+    public static int bucketsFromFormattedValue(String uiInput, BucketMode bucketMode) {
+        if (bucketMode == BucketMode.MILLI_BUCKET) return Integer.parseInt(uiInput);
+        if (!uiInput.contains(".")) return Integer.parseInt(uiInput) * 1000;
+        String[] splitInput = uiInput.split("\\.");
+        return (Integer.parseInt(splitInput[0]) * 1000) + Integer.parseInt(splitInput[1]);
     }
 
     public static SlotGroupWidget verticalPlayerInventory(SlotGroupWidget.SlotConsumer slotConsumer) {

--- a/src/main/java/com/gregtechceu/gtceu/common/mui/GTMuiWidgets.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/mui/GTMuiWidgets.java
@@ -641,6 +641,7 @@ public class GTMuiWidgets {
         if (bucketMode == BucketMode.MILLI_BUCKET) return Integer.parseInt(uiInput);
         if (!uiInput.contains(".")) return Integer.parseInt(uiInput) * 1000;
         String[] splitInput = uiInput.split("\\.");
+        if (splitInput.length > 1 && splitInput[1].length() > 3) splitInput[1] = splitInput[1].substring(0, 3);
         return (Integer.parseInt(splitInput[0]) * 1000) + Integer.parseInt(splitInput[1]);
     }
 


### PR DESCRIPTION
## What
Two (related) changes:

1. Bucket Mode toggle only alters the increment of the +/- buttons and scrollwheel. But the readout showing current config value always displays as millibuckets, meaning that it looks like bucket mode has no effect.
2. Fluid Regulators could not be set to SupplyExact or KeepExact values higher than their per-tick transfer limit, severely limiting the usefulness of lower-tier Regulators (and drastically limiting their throughput to only 5% of what it should be). In contrast, Robot Arms have no such limitation on their SE/KE values.

## Implementation Details
Bucket Mode toggle now changes the display to show its value as B.MMM. The decimal conversion is only visual, using a StringBuilder to inject a `.` and a `.split()` to parse the input; all values are still stored as integer millibuckets.
SE/KE input values are now fully uncapped. This does not break behavior as the existing SE/KE transfer modes would buffer any transfers if the cover couldn't send enough in a single action.

### AI Usage 
- [ X ] No AI driven tools were used for this pull request.

## Outcome
<img width="421" height="342" alt="image" src="https://github.com/user-attachments/assets/2a0bf1b2-a5c1-42b1-9431-56dcb9f065a6" />

